### PR TITLE
Create BlobStore interface

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -2,6 +2,7 @@ package cascade
 
 import (
 	"errors"
+	"io"
 
 	"github.com/opencontainers/go-digest"
 	"github.com/robinkb/cascade-registry/paths"
@@ -20,7 +21,7 @@ func (s *registryService) StatBlob(repository, id string) (*FileInfo, error) {
 	}
 
 	dataPath := paths.BlobStore.BlobData(digest)
-	info, err := s.store.Stat(dataPath)
+	info, err := s.b.Stat(dataPath)
 	if errors.Is(err, ErrFileNotFound) {
 		return nil, ErrBlobUnknown
 	}
@@ -41,7 +42,11 @@ func (s *registryService) GetBlob(repository, id string) ([]byte, error) {
 	}
 
 	dataPath := paths.BlobStore.BlobData(digest)
-	data, err := s.store.Get(dataPath)
+	r, err := s.b.Reader(dataPath)
+	if err != nil {
+		return nil, err
+	}
+	data, err := io.ReadAll(r)
 	if errors.Is(err, ErrFileNotFound) {
 		return nil, ErrBlobUnknown
 	}

--- a/blobs.go
+++ b/blobs.go
@@ -29,7 +29,7 @@ func (s *registryService) StatBlob(repository, id string) (*FileInfo, error) {
 	return info, err
 }
 
-func (s *registryService) GetBlob(repository, id string) ([]byte, error) {
+func (s *registryService) GetBlob(repository, id string) (io.Reader, error) {
 	digest, err := digest.Parse(id)
 	if err != nil {
 		return nil, ErrBlobUnknown
@@ -42,14 +42,5 @@ func (s *registryService) GetBlob(repository, id string) ([]byte, error) {
 	}
 
 	dataPath := paths.BlobStore.BlobData(digest)
-	r, err := s.b.Reader(dataPath)
-	if err != nil {
-		return nil, err
-	}
-	data, err := io.ReadAll(r)
-	if errors.Is(err, ErrFileNotFound) {
-		return nil, ErrBlobUnknown
-	}
-
-	return data, err
+	return s.b.Reader(dataPath)
 }

--- a/blobs_test.go
+++ b/blobs_test.go
@@ -1,6 +1,7 @@
 package cascade
 
 import (
+	"io"
 	"testing"
 
 	"github.com/robinkb/cascade-registry/paths"
@@ -43,20 +44,20 @@ func TestGetBlob(t *testing.T) {
 	store.Set(paths.MetaStore.BlobLink(name, digest), nil)
 
 	t.Run("Known blob returns content and no error", func(t *testing.T) {
-		data, err := service.GetBlob(name, digest.String())
-		assertContent(t, data, content)
+		r, err := service.GetBlob(name, digest.String())
 		assertNoError(t, err)
+		data, err := io.ReadAll(r)
+		assertNoError(t, err)
+		assertContent(t, data, content)
 	})
 
 	t.Run("Unknown blob returns no content and ErrBlobUnknown", func(t *testing.T) {
-		data, err := service.GetBlob("fake/repository", "blabla")
-		assertContent(t, data, nil)
+		_, err := service.GetBlob("fake/repository", "blabla")
 		assertErrorIs(t, err, ErrBlobUnknown)
 	})
 
 	t.Run("Known blob on unknown repository still returns no content and ErrBlobUnknown", func(t *testing.T) {
-		data, err := service.GetBlob("fake/repository", digest.String())
-		assertContent(t, data, nil)
+		_, err := service.GetBlob("fake/repository", digest.String())
 		assertErrorIs(t, err, ErrBlobUnknown)
 	})
 }

--- a/blobs_test.go
+++ b/blobs_test.go
@@ -13,9 +13,8 @@ func TestStatBlob(t *testing.T) {
 
 	name, digest, content := randomBlob(32 * 1024)
 
+	service.b.Put(paths.BlobStore.BlobData(digest), content)
 	store.Set(paths.MetaStore.BlobLink(name, digest), nil)
-	w, _ := service.b.Writer(paths.BlobStore.BlobData(digest))
-	w.Write(content)
 
 	t.Run("Known blob returns no error", func(t *testing.T) {
 		_, err := service.StatBlob(name, digest.String())
@@ -39,8 +38,7 @@ func TestGetBlob(t *testing.T) {
 
 	name, digest, content := randomBlob(32)
 
-	w, _ := service.b.Writer(paths.BlobStore.BlobData(digest))
-	w.Write(content)
+	service.b.Put(paths.BlobStore.BlobData(digest), content)
 	store.Set(paths.MetaStore.BlobLink(name, digest), nil)
 
 	t.Run("Known blob returns content and no error", func(t *testing.T) {

--- a/blobs_test.go
+++ b/blobs_test.go
@@ -13,7 +13,8 @@ func TestStatBlob(t *testing.T) {
 	name, digest, content := randomBlob(32 * 1024)
 
 	store.Set(paths.MetaStore.BlobLink(name, digest), nil)
-	store.Set(paths.BlobStore.BlobData(digest), content)
+	w, _ := service.b.Writer(paths.BlobStore.BlobData(digest))
+	w.Write(content)
 
 	t.Run("Known blob returns no error", func(t *testing.T) {
 		_, err := service.StatBlob(name, digest.String())
@@ -37,7 +38,8 @@ func TestGetBlob(t *testing.T) {
 
 	name, digest, content := randomBlob(32)
 
-	store.Set(paths.BlobStore.BlobData(digest), content)
+	w, _ := service.b.Writer(paths.BlobStore.BlobData(digest))
+	w.Write(content)
 	store.Set(paths.MetaStore.BlobLink(name, digest), nil)
 
 	t.Run("Known blob returns content and no error", func(t *testing.T) {

--- a/manifests.go
+++ b/manifests.go
@@ -3,7 +3,6 @@ package cascade
 import (
 	"encoding/json"
 	"errors"
-	"io"
 
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -64,12 +63,7 @@ func (s *registryService) GetManifest(repository, id string) (*Manifest, error) 
 	}
 
 	dataPath := paths.BlobStore.BlobData(digest)
-	r, err := s.b.Reader(dataPath)
-	if errors.Is(err, ErrFileNotFound) {
-		return nil, ErrManifestUnknown
-	}
-
-	content, err := io.ReadAll(r)
+	content, err := s.b.Get(dataPath)
 	if err != nil {
 		return nil, err
 	}
@@ -91,17 +85,11 @@ func (s *registryService) PutManifest(repository, reference string, content []by
 	dataPath := paths.BlobStore.BlobData(digest)
 	linkPath := paths.MetaStore.ManifestLink(repository, digest)
 
-	w, err := s.b.Writer(dataPath)
+	err = s.b.Put(dataPath, content)
 	if err != nil {
 		return err
 	}
-	if _, err = w.Write(content); err != nil {
-		return err
-	}
-
-	s.store.Set(linkPath, nil)
-
-	return nil
+	return s.store.Set(linkPath, nil)
 }
 
 func (s *registryService) DeleteManifest(repository, id string) error {

--- a/manifests.go
+++ b/manifests.go
@@ -3,6 +3,7 @@ package cascade
 import (
 	"encoding/json"
 	"errors"
+	"io"
 
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -42,7 +43,7 @@ func (s *registryService) StatManifest(repository, id string) (*FileInfo, error)
 	}
 
 	dataPath := paths.BlobStore.BlobData(digest)
-	info, err := s.store.Stat(dataPath)
+	info, err := s.b.Stat(dataPath)
 	if errors.Is(err, ErrFileNotFound) {
 		return nil, ErrManifestUnknown
 	}
@@ -63,9 +64,14 @@ func (s *registryService) GetManifest(repository, id string) (*Manifest, error) 
 	}
 
 	dataPath := paths.BlobStore.BlobData(digest)
-	content, err := s.store.Get(dataPath)
+	r, err := s.b.Reader(dataPath)
 	if errors.Is(err, ErrFileNotFound) {
 		return nil, ErrManifestUnknown
+	}
+
+	content, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
 	}
 
 	return NewManifest(content)
@@ -85,7 +91,14 @@ func (s *registryService) PutManifest(repository, reference string, content []by
 	dataPath := paths.BlobStore.BlobData(digest)
 	linkPath := paths.MetaStore.ManifestLink(repository, digest)
 
-	s.store.Set(dataPath, content)
+	w, err := s.b.Writer(dataPath)
+	if err != nil {
+		return err
+	}
+	if _, err = w.Write(content); err != nil {
+		return err
+	}
+
 	s.store.Set(linkPath, nil)
 
 	return nil
@@ -104,7 +117,7 @@ func (s *registryService) DeleteManifest(repository, id string) error {
 	}
 
 	dataPath := paths.BlobStore.BlobData(digest)
-	s.store.Delete(dataPath)
+	s.b.Delete(dataPath)
 	s.store.Delete(linkPath)
 
 	return err

--- a/manifests_test.go
+++ b/manifests_test.go
@@ -17,7 +17,9 @@ func TestStatManifest(t *testing.T) {
 	manifest, _ := json.Marshal(v1.Manifest{MediaType: v1.MediaTypeImageLayer})
 	digest := digest.FromBytes(manifest)
 
-	store.Set(paths.BlobStore.BlobData(digest), manifest)
+	w, _ := service.b.Writer(paths.BlobStore.BlobData(digest))
+	w.Write(manifest)
+
 	store.Set(paths.MetaStore.ManifestLink(name, digest), nil)
 	store.Set(paths.MetaStore.TagLink(name, "40"), []byte(digest.String()))
 
@@ -58,7 +60,8 @@ func TestGetManifest(t *testing.T) {
 	manifest, _ := json.Marshal(v1.Manifest{MediaType: v1.MediaTypeImageLayer})
 	digest := digest.FromBytes(manifest)
 
-	store.Set(paths.BlobStore.BlobData(digest), manifest)
+	w, _ := service.b.Writer(paths.BlobStore.BlobData(digest))
+	w.Write(manifest)
 	store.Set(paths.MetaStore.ManifestLink(name, digest), nil)
 	store.Set(paths.MetaStore.TagLink(name, "40"), []byte(digest.String()))
 

--- a/manifests_test.go
+++ b/manifests_test.go
@@ -17,9 +17,7 @@ func TestStatManifest(t *testing.T) {
 	manifest, _ := json.Marshal(v1.Manifest{MediaType: v1.MediaTypeImageLayer})
 	digest := digest.FromBytes(manifest)
 
-	w, _ := service.b.Writer(paths.BlobStore.BlobData(digest))
-	w.Write(manifest)
-
+	service.b.Put(paths.BlobStore.BlobData(digest), manifest)
 	store.Set(paths.MetaStore.ManifestLink(name, digest), nil)
 	store.Set(paths.MetaStore.TagLink(name, "40"), []byte(digest.String()))
 
@@ -60,8 +58,7 @@ func TestGetManifest(t *testing.T) {
 	manifest, _ := json.Marshal(v1.Manifest{MediaType: v1.MediaTypeImageLayer})
 	digest := digest.FromBytes(manifest)
 
-	w, _ := service.b.Writer(paths.BlobStore.BlobData(digest))
-	w.Write(manifest)
+	service.b.Put(paths.BlobStore.BlobData(digest), manifest)
 	store.Set(paths.MetaStore.ManifestLink(name, digest), nil)
 	store.Set(paths.MetaStore.TagLink(name, "40"), []byte(digest.String()))
 

--- a/scratch/scratch.go
+++ b/scratch/scratch.go
@@ -1,6 +1,8 @@
 package scratch
 
-import "context"
+import (
+	"context"
+)
 
 type (
 	Registry interface {
@@ -9,7 +11,6 @@ type (
 	}
 
 	RepositoryManager interface {
-
 		// These could do validation on the digest and such?
 		Blob(digest string) (BlobManager, error)
 		Manifest(digest string) (ManifestManager, error)
@@ -49,7 +50,4 @@ type (
 
 	FileInfo      struct{}
 	UploadSession struct{}
-
-	BlobStore     interface{}
-	MetadataStore interface{}
 )

--- a/server/blob_uploads.go
+++ b/server/blob_uploads.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -60,18 +61,20 @@ func (s *Server) chunkedUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	expectedLength := givenEnd - givenStart
+
 	content, err := io.ReadAll(r.Body)
 	if err != nil {
 		writeErrorResponse(w, err)
 		return
 	}
 
-	if int64(len(content)-1) != givenEnd-givenStart {
+	if int64(len(content)-1) != expectedLength {
 		w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
 		return
 	}
 
-	if err := s.service.AppendUpload(repository, reference, content, givenStart); err != nil {
+	if err := s.service.AppendUpload(repository, reference, bytes.NewBuffer(content), givenStart); err != nil {
 		writeErrorResponse(w, err)
 		return
 	}
@@ -86,13 +89,7 @@ func (s *Server) streamedUploadHandler(w http.ResponseWriter, r *http.Request) {
 	repository := r.PathValue("repository")
 	reference := r.PathValue("reference")
 
-	content, err := io.ReadAll(r.Body)
-	if err != nil {
-		writeErrorResponse(w, err)
-		return
-	}
-
-	if err := s.service.AppendUpload(repository, reference, content, 0); err != nil {
+	if err := s.service.AppendUpload(repository, reference, r.Body, 0); err != nil {
 		writeErrorResponse(w, err)
 		return
 	}
@@ -130,7 +127,7 @@ func (s *Server) closeUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 		content, _ := io.ReadAll(r.Body)
 		// TODO: Check this error
-		s.service.AppendUpload(repository, reference, content, offset)
+		s.service.AppendUpload(repository, reference, bytes.NewBuffer(content), offset)
 	}
 
 	digest := r.URL.Query().Get("digest")

--- a/server/blobs.go
+++ b/server/blobs.go
@@ -1,6 +1,9 @@
 package server
 
-import "net/http"
+import (
+	"io"
+	"net/http"
+)
 
 func (s *Server) blobsHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
@@ -29,12 +32,12 @@ func (s *Server) getBlobsHandler(w http.ResponseWriter, r *http.Request) {
 	repository := r.PathValue("repository")
 	digest := r.PathValue("digest")
 
-	content, err := s.service.GetBlob(repository, digest)
+	blob, err := s.service.GetBlob(repository, digest)
 	if err != nil {
 		writeErrorResponse(w, err)
 		return
 	}
 
 	w.WriteHeader(http.StatusOK)
-	w.Write(content)
+	io.Copy(w, blob)
 }

--- a/server/blobs_test.go
+++ b/server/blobs_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -45,8 +47,8 @@ func TestGetBlob(t *testing.T) {
 	t.Run("Get blob returns 200", func(t *testing.T) {
 		content := randomContents(32)
 		server := New(&StubRegistryService{
-			getBlob: func(repository, digest string) ([]byte, error) {
-				return content, nil
+			getBlob: func(repository, digest string) (io.Reader, error) {
+				return bytes.NewBuffer(content), nil
 			},
 		})
 
@@ -60,7 +62,7 @@ func TestGetBlob(t *testing.T) {
 
 	t.Run("returns 404 on unknown blob", func(t *testing.T) {
 		server := New(&StubRegistryService{
-			getBlob: func(repository, digest string) ([]byte, error) {
+			getBlob: func(repository, digest string) (io.Reader, error) {
 				return nil, cascade.ErrBlobUnknown
 			},
 		})

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
+	"io"
 	"strings"
 
 	"net/http"
@@ -23,7 +24,7 @@ var (
 
 type StubRegistryService struct {
 	statBlob func(repository, digest string) (*cascade.FileInfo, error)
-	getBlob  func(repository, digest string) ([]byte, error)
+	getBlob  func(repository, digest string) (io.Reader, error)
 
 	statManifest   func(repository, reference string) (*cascade.FileInfo, error)
 	getManifest    func(repository, reference string) (*cascade.Manifest, error)
@@ -44,7 +45,7 @@ type StubRegistryService struct {
 func (s *StubRegistryService) StatBlob(repository, digest string) (*cascade.FileInfo, error) {
 	return s.statBlob(repository, digest)
 }
-func (s *StubRegistryService) GetBlob(repository, digest string) ([]byte, error) {
+func (s *StubRegistryService) GetBlob(repository, digest string) (io.Reader, error) {
 	return s.getBlob(repository, digest)
 }
 func (s *StubRegistryService) StatManifest(repository, reference string) (*cascade.FileInfo, error) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -38,7 +38,7 @@ type StubRegistryService struct {
 
 	initUpload   func(repository string) *cascade.UploadSession
 	statUpload   func(repository, sessionID string) (*cascade.FileInfo, error)
-	appendUpload func(repository, sessionID string, content []byte, offset int64) error
+	appendUpload func(repository, sessionID string, r io.Reader, offset int64) error
 	closeUpload  func(repository, id, digest string) error
 }
 
@@ -78,8 +78,8 @@ func (s *StubRegistryService) InitUpload(repository string) *cascade.UploadSessi
 func (s *StubRegistryService) StatUpload(repository, sessionID string) (*cascade.FileInfo, error) {
 	return s.statUpload(repository, sessionID)
 }
-func (s *StubRegistryService) AppendUpload(repository, sessionID string, content []byte, size int64) error {
-	return s.appendUpload(repository, sessionID, content, size)
+func (s *StubRegistryService) AppendUpload(repository, sessionID string, r io.Reader, offset int64) error {
+	return s.appendUpload(repository, sessionID, r, offset)
 }
 func (s *StubRegistryService) CloseUpload(repository, id, digest string) error {
 	return s.closeUpload(repository, id, digest)

--- a/service.go
+++ b/service.go
@@ -1,9 +1,11 @@
 package cascade
 
+import "io"
+
 type (
 	RegistryService interface {
 		StatBlob(repository, digest string) (*FileInfo, error)
-		GetBlob(repository, digest string) ([]byte, error)
+		GetBlob(repository, digest string) (io.Reader, error)
 
 		StatManifest(repository, reference string) (*FileInfo, error)
 		GetManifest(repository, reference string) (*Manifest, error)

--- a/service.go
+++ b/service.go
@@ -47,11 +47,13 @@ type (
 func NewRegistryService(store RegistryStore) *registryService {
 	return &registryService{
 		store:        store,
+		b:            NewInMemoryBlobStore(),
 		sessionStore: make(map[string]map[string]bool),
 	}
 }
 
 type registryService struct {
 	store        RegistryStore
+	b            BlobStore
 	sessionStore map[string]map[string]bool
 }

--- a/service.go
+++ b/service.go
@@ -19,7 +19,7 @@ type (
 
 		InitUpload(repository string) *UploadSession
 		StatUpload(repository, sessionID string) (*FileInfo, error)
-		AppendUpload(repository, sessionID string, content []byte, offset int64) error
+		AppendUpload(repository, sessionID string, r io.Reader, offset int64) error
 		CloseUpload(repository, id, digest string) error
 	}
 

--- a/store.go
+++ b/store.go
@@ -26,10 +26,17 @@ type (
 	}
 
 	BlobStore interface {
+		// Stat returns basic file info about the blob at the given path.
 		Stat(path string) (*FileInfo, error)
+		// Reader returns an io.Reader that can be used to read a blob.
 		Reader(path string) (io.Reader, error)
+		// Writer returns an io.Writer to write to a blob. Blobs are always appended to.
+		// If a blob must be truncated, delete it first.
 		Writer(path string) (io.Writer, error)
+		// Delete removes the blob at the given path.
 		Delete(path string) error
+		// Move moves the blob from the source path to the destination path.
+		// This may effectively be a rename on some backends.
 		Move(sourcePath, destinationPath string) error
 	}
 

--- a/store.go
+++ b/store.go
@@ -28,6 +28,13 @@ type (
 	BlobStore interface {
 		// Stat returns basic file info about the blob at the given path.
 		Stat(path string) (*FileInfo, error)
+		// Get returns the blob at the given path. Intended for smaller blobs that
+		// must be fully read into memory server-side, like manifests.
+		Get(path string) ([]byte, error)
+		// Put writes content to the given path. Intended for smaller blobs that
+		// must be fully read into memory server-side, like manifests.
+		// Unlike Writer, Put does not append and always writes the entire blob.
+		Put(path string, content []byte) error
 		// Reader returns an io.Reader that can be used to read a blob.
 		Reader(path string) (io.Reader, error)
 		// Writer returns an io.Writer to write to a blob. Blobs are always appended to.
@@ -166,6 +173,26 @@ func (s *InMemoryBlobStore) Stat(path string) (*FileInfo, error) {
 		Name: path,
 		Size: int64(len(data)),
 	}, nil
+}
+
+func (s *InMemoryBlobStore) Get(path string) ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	data, ok := s.store[path]
+	if !ok {
+		return nil, ErrFileNotFound
+	}
+	return data, nil
+}
+
+func (s *InMemoryBlobStore) Put(path string, content []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.store[path] = content
+
+	return nil
 }
 
 func (s *InMemoryBlobStore) Reader(path string) (io.Reader, error) {

--- a/store.go
+++ b/store.go
@@ -1,7 +1,9 @@
 package cascade
 
 import (
+	"bytes"
 	"errors"
+	"io"
 	"sync"
 )
 
@@ -18,6 +20,17 @@ type (
 		Put(path string, content []byte) error
 		Delete(path string) error
 		Move(sourcePath, destinationPath string)
+	}
+
+	MetadataStore interface {
+	}
+
+	BlobStore interface {
+		Stat(path string) (*FileInfo, error)
+		Reader(path string) (io.Reader, error)
+		Writer(path string) (io.Writer, error)
+		Delete(path string) error
+		Move(sourcePath, destinationPath string) error
 	}
 
 	// Based (at least initially) on fs.FileInfo interface.
@@ -107,4 +120,70 @@ func (s *InMemoryStore) Move(sourcePath, destinationPath string) {
 
 	s.store[destinationPath] = s.store[sourcePath]
 	delete(s.store, sourcePath)
+}
+
+func NewInMemoryBlobStore() BlobStore {
+	return &InMemoryBlobStore{
+		store: make(map[string][]byte),
+	}
+}
+
+type InMemoryBlobStore struct {
+	store map[string][]byte
+	mu    sync.RWMutex
+}
+
+type writer struct {
+	s    *InMemoryBlobStore
+	path string
+}
+
+func (w *writer) Write(p []byte) (n int, err error) {
+	w.s.mu.Lock()
+	defer w.s.mu.Unlock()
+
+	w.s.store[w.path] = append(w.s.store[w.path], p...)
+	return len(p), nil
+}
+
+func (s *InMemoryBlobStore) Stat(path string) (*FileInfo, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	data, ok := s.store[path]
+	if !ok {
+		return nil, ErrFileNotFound
+	}
+
+	return &FileInfo{
+		Name: path,
+		Size: int64(len(data)),
+	}, nil
+}
+
+func (s *InMemoryBlobStore) Reader(path string) (io.Reader, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return bytes.NewBuffer(s.store[path]), nil
+}
+
+func (s *InMemoryBlobStore) Writer(path string) (io.Writer, error) {
+	return &writer{s, path}, nil
+}
+
+func (s *InMemoryBlobStore) Delete(path string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.store, path)
+	return nil
+}
+
+func (s *InMemoryBlobStore) Move(sourcePath, destinationPath string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.store[destinationPath] = s.store[sourcePath]
+	return nil
 }

--- a/uploads.go
+++ b/uploads.go
@@ -5,6 +5,7 @@ import (
 	"encoding"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/robinkb/cascade-registry/paths"
 
@@ -65,7 +66,7 @@ func (s *registryService) InitUpload(repository string) *UploadSession {
 }
 
 // TODO: Verify that this is properly scoped to a repository.
-func (s *registryService) AppendUpload(repository, sessionID string, content []byte, offset int64) error {
+func (s *registryService) AppendUpload(repository, sessionID string, r io.Reader, offset int64) error {
 	info, err := s.StatUpload(repository, sessionID)
 	if err != nil {
 		return err
@@ -88,9 +89,17 @@ func (s *registryService) AppendUpload(repository, sessionID string, content []b
 	if err != nil {
 		return err
 	}
-	_, err = hash.Write(content)
+
+	dataPath := paths.BlobStore.UploadData(sessionID)
+	w, err := s.b.Writer(dataPath)
 	if err != nil {
-		panic(err)
+		return err
+	}
+
+	tee := io.TeeReader(r, hash)
+	_, err = io.Copy(w, tee)
+	if err != nil {
+		return err
 	}
 
 	hashState, err = hash.(encoding.BinaryMarshaler).MarshalBinary()
@@ -98,18 +107,7 @@ func (s *registryService) AppendUpload(repository, sessionID string, content []b
 		panic(err)
 	}
 
-	err = s.store.Set(hashPath, hashState)
-	if err != nil {
-		panic(err)
-	}
-
-	dataPath := paths.BlobStore.UploadData(sessionID)
-	w, err := s.b.Writer(dataPath)
-	if err != nil {
-		return err
-	}
-	_, err = w.Write(content)
-	return err
+	return s.store.Set(hashPath, hashState)
 }
 
 func (s *registryService) CloseUpload(repository, sessionID, digest string) error {

--- a/uploads.go
+++ b/uploads.go
@@ -17,7 +17,7 @@ import (
 func (s *registryService) StatUpload(repository, sessionID string) (*FileInfo, error) {
 	path := paths.BlobStore.UploadData(sessionID)
 
-	info, err := s.store.Stat(path)
+	info, err := s.b.Stat(path)
 	if errors.Is(err, ErrFileNotFound) {
 		return nil, ErrBlobUploadUnknown
 	}
@@ -49,7 +49,11 @@ func (s *registryService) InitUpload(repository string) *UploadSession {
 	}
 
 	dataPath := paths.BlobStore.UploadData(sessionID.String())
-	err = s.store.Set(dataPath, []byte{})
+	w, err := s.b.Writer(dataPath)
+	if err != nil {
+		panic(err)
+	}
+	_, err = w.Write([]byte{})
 	if err != nil {
 		panic(err)
 	}
@@ -62,8 +66,6 @@ func (s *registryService) InitUpload(repository string) *UploadSession {
 
 // TODO: Verify that this is properly scoped to a repository.
 func (s *registryService) AppendUpload(repository, sessionID string, content []byte, offset int64) error {
-	dataPath := paths.BlobStore.UploadData(sessionID)
-
 	info, err := s.StatUpload(repository, sessionID)
 	if err != nil {
 		return err
@@ -101,7 +103,12 @@ func (s *registryService) AppendUpload(repository, sessionID string, content []b
 		panic(err)
 	}
 
-	err = s.store.Put(dataPath, content)
+	dataPath := paths.BlobStore.UploadData(sessionID)
+	w, err := s.b.Writer(dataPath)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(content)
 	return err
 }
 
@@ -137,7 +144,7 @@ func (s *registryService) CloseUpload(repository, sessionID, digest string) erro
 	destPath := paths.BlobStore.BlobData(id)
 	linkPath := paths.MetaStore.BlobLink(repository, id)
 
-	s.store.Move(sourcePath, destPath)
+	s.b.Move(sourcePath, destPath)
 	s.store.Set(linkPath, nil)
 	return nil
 }

--- a/uploads_test.go
+++ b/uploads_test.go
@@ -1,6 +1,7 @@
 package cascade
 
 import (
+	"bytes"
 	"io"
 	"reflect"
 	"testing"
@@ -17,7 +18,7 @@ func TestStatUpload(t *testing.T) {
 		content := randomContents(32)
 
 		session := service.InitUpload(repository)
-		err := service.AppendUpload(repository, session.ID, content, 0)
+		err := service.AppendUpload(repository, session.ID, bytes.NewBuffer(content), 0)
 		assertNoError(t, err)
 
 		info, err := service.StatUpload(repository, session.ID)
@@ -45,7 +46,7 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 
 		session := service.InitUpload(name)
 
-		err := service.AppendUpload(name, session.ID, content, 0)
+		err := service.AppendUpload(name, session.ID, bytes.NewBuffer(content), 0)
 		assertNoError(t, err)
 
 		err = service.CloseUpload(name, session.ID, digest.String())
@@ -59,7 +60,7 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 	})
 
 	t.Run("Uploading without a session returns ErrBlobUploadUknown", func(t *testing.T) {
-		err := service.AppendUpload("fake", "abc", []byte{}, 0)
+		err := service.AppendUpload("fake", "abc", nil, 0)
 		assertErrorIs(t, err, ErrBlobUploadUnknown)
 	})
 
@@ -69,7 +70,7 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 
 		session := service.InitUpload(name)
 
-		err := service.AppendUpload(name, session.ID, content[0:16], 0)
+		err := service.AppendUpload(name, session.ID, bytes.NewBuffer(content[0:16]), 0)
 		assertNoError(t, err)
 
 		err = service.CloseUpload(name, session.ID, digest)
@@ -82,7 +83,7 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 
 		session := service.InitUpload(name)
 
-		err := service.AppendUpload(name, session.ID, otherContent, 0)
+		err := service.AppendUpload(name, session.ID, bytes.NewBuffer(otherContent), 0)
 		assertNoError(t, err)
 
 		err = service.CloseUpload(name, session.ID, digest.String())
@@ -100,7 +101,7 @@ func TestServiceUpload(t *testing.T) {
 
 		session := service.InitUpload(repository)
 
-		err := service.AppendUpload(repository, session.ID, content, 0)
+		err := service.AppendUpload(repository, session.ID, bytes.NewBuffer(content), 0)
 		assertNoError(t, err)
 
 		r, err := service.b.Reader(paths.BlobStore.UploadData(session.ID))
@@ -120,10 +121,10 @@ func TestServiceUpload(t *testing.T) {
 
 		session := service.InitUpload(repository)
 
-		err := service.AppendUpload(repository, session.ID, content[:16], 0)
+		err := service.AppendUpload(repository, session.ID, bytes.NewBuffer(content[:16]), 0)
 		assertNoError(t, err)
 
-		err = service.AppendUpload(repository, session.ID, content[16:], 16)
+		err = service.AppendUpload(repository, session.ID, bytes.NewBuffer(content[16:]), 16)
 		assertNoError(t, err)
 
 		info, err := service.StatUpload(repository, session.ID)
@@ -138,7 +139,7 @@ func TestServiceUpload(t *testing.T) {
 	})
 
 	t.Run("writing to unknown upload returns ErrBlobUploadUnknown", func(t *testing.T) {
-		err := service.AppendUpload("1/2/3", "i-dont-exist", []byte{}, 0)
+		err := service.AppendUpload("1/2/3", "i-dont-exist", nil, 0)
 		assertErrorIs(t, err, ErrBlobUploadUnknown)
 	})
 }

--- a/uploads_test.go
+++ b/uploads_test.go
@@ -51,9 +51,11 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 		err = service.CloseUpload(name, session.ID, digest.String())
 		assertNoError(t, err)
 
-		data, err := service.GetBlob(name, digest.String())
-		assertContent(t, data, content)
+		r, err := service.GetBlob(name, digest.String())
 		assertNoError(t, err)
+		data, err := io.ReadAll(r)
+		assertNoError(t, err)
+		assertContent(t, data, content)
 	})
 
 	t.Run("Uploading without a session returns ErrBlobUploadUknown", func(t *testing.T) {

--- a/uploads_test.go
+++ b/uploads_test.go
@@ -1,6 +1,7 @@
 package cascade
 
 import (
+	"io"
 	"reflect"
 	"testing"
 
@@ -13,13 +14,13 @@ func TestStatUpload(t *testing.T) {
 
 	t.Run("stat upload returns correct FileInfo", func(t *testing.T) {
 		repository := "a/v/c"
-		sessionID := "123"
 		content := randomContents(32)
 
-		store.Set(paths.MetaStore.UploadLink(repository, sessionID), nil)
-		store.Set(paths.BlobStore.UploadData(sessionID), content)
+		session := service.InitUpload(repository)
+		err := service.AppendUpload(repository, session.ID, content, 0)
+		assertNoError(t, err)
 
-		info, err := service.StatUpload(repository, sessionID)
+		info, err := service.StatUpload(repository, session.ID)
 		assertNoError(t, err)
 
 		got := info.Size
@@ -100,7 +101,10 @@ func TestServiceUpload(t *testing.T) {
 		err := service.AppendUpload(repository, session.ID, content, 0)
 		assertNoError(t, err)
 
-		got, err := store.Get(paths.BlobStore.UploadData(session.ID))
+		r, err := service.b.Reader(paths.BlobStore.UploadData(session.ID))
+		assertNoError(t, err)
+
+		got, err := io.ReadAll(r)
 		assertNoError(t, err)
 
 		if !reflect.DeepEqual(got, content) {


### PR DESCRIPTION
Start splitting up the RegistryStore interface into the more focused BlobStore and MetadataStore. Aligns with my future plans for using the filesystem as the blob store, and a transactional key/value store as the metadata store.