### PR TITLE
Use testing package everywhere

### DIFF
--- a/blobs_test.go
+++ b/blobs_test.go
@@ -5,11 +5,16 @@ import (
 	"testing"
 
 	"github.com/robinkb/cascade-registry"
+	"github.com/robinkb/cascade-registry/store/inmemory"
+	. "github.com/robinkb/cascade-registry/testing"
 )
 
 func TestStatBlob(t *testing.T) {
-	service, metadata, blobs := newTestRegistry()
+	metadata := inmemory.NewMetadataStore()
+	blobs := inmemory.NewBlobStore()
+	service := cascade.NewRegistryService(metadata, blobs)
 
+	name := RandomName()
 	name, digest, content := randomBlob(32 * 1024)
 	path := digest.Encoded()
 
@@ -18,7 +23,7 @@ func TestStatBlob(t *testing.T) {
 
 	t.Run("Known blob returns no error", func(t *testing.T) {
 		_, err := service.StatBlob(name, digest.String())
-		assertNoError(t, err)
+		AssertNoError(t, err)
 	})
 
 	t.Run("Unknown blob returns ErrBlobUnknown", func(t *testing.T) {

--- a/blobs_test.go
+++ b/blobs_test.go
@@ -15,7 +15,7 @@ func TestStatBlob(t *testing.T) {
 	service := cascade.NewRegistryService(metadata, blobs)
 
 	name := RandomName()
-	name, digest, content := randomBlob(32 * 1024)
+	digest, content := RandomBlob(32 * 1024)
 	path := digest.Encoded()
 
 	blobs.Put(path, content)
@@ -28,19 +28,20 @@ func TestStatBlob(t *testing.T) {
 
 	t.Run("Unknown blob returns ErrBlobUnknown", func(t *testing.T) {
 		_, err := service.StatBlob("a", "b")
-		assertErrorIs(t, err, cascade.ErrBlobUnknown)
+		AssertErrorIs(t, err, cascade.ErrBlobUnknown)
 	})
 
 	t.Run("Known blob in unknown repository returns ErrBlobUnknown", func(t *testing.T) {
 		_, err := service.StatBlob("fake/repository", digest.String())
-		assertErrorIs(t, err, cascade.ErrBlobUnknown)
+		AssertErrorIs(t, err, cascade.ErrBlobUnknown)
 	})
 }
 
 func TestGetBlob(t *testing.T) {
 	service, metadata, blobs := newTestRegistry()
 
-	name, digest, content := randomBlob(32)
+	name := RandomName()
+	digest, content := RandomBlob(32)
 	path := digest.Encoded()
 
 	blobs.Put(path, content)
@@ -48,27 +49,28 @@ func TestGetBlob(t *testing.T) {
 
 	t.Run("Known blob returns content and no error", func(t *testing.T) {
 		r, err := service.GetBlob(name, digest.String())
-		assertNoError(t, err)
+		AssertNoError(t, err)
 		data, err := io.ReadAll(r)
-		assertNoError(t, err)
-		assertContent(t, data, content)
+		AssertNoError(t, err)
+		AssertSlicesEqual(t, data, content)
 	})
 
 	t.Run("Unknown blob returns no content and ErrBlobUnknown", func(t *testing.T) {
 		_, err := service.GetBlob("fake/repository", "blabla")
-		assertErrorIs(t, err, cascade.ErrBlobUnknown)
+		AssertErrorIs(t, err, cascade.ErrBlobUnknown)
 	})
 
 	t.Run("Known blob on unknown repository still returns no content and ErrBlobUnknown", func(t *testing.T) {
 		_, err := service.GetBlob("fake/repository", digest.String())
-		assertErrorIs(t, err, cascade.ErrBlobUnknown)
+		AssertErrorIs(t, err, cascade.ErrBlobUnknown)
 	})
 }
 
 func TestDeleteBlob(t *testing.T) {
 	service, metadata, blobs := newTestRegistry()
 
-	name, digest, content := randomBlob(32)
+	name := RandomName()
+	digest, content := RandomBlob(32)
 	path := digest.String()
 
 	t.Run("A deleted blob is not retrievable", func(t *testing.T) {
@@ -76,12 +78,12 @@ func TestDeleteBlob(t *testing.T) {
 		blobs.Put(path, content)
 
 		_, err := service.GetBlob(name, digest.String())
-		assertNoError(t, err)
+		RequireNoError(t, err)
 
 		err = service.DeleteBlob(name, digest.String())
-		assertNoError(t, err)
+		RequireNoError(t, err)
 
 		_, err = service.GetBlob(name, digest.String())
-		assertErrorIs(t, err, cascade.ErrBlobUnknown)
+		AssertErrorIs(t, err, cascade.ErrBlobUnknown)
 	})
 }

--- a/errors.go
+++ b/errors.go
@@ -1,5 +1,7 @@
 package cascade
 
+import "strings"
+
 var (
 	// Error codes as defined in the Distribution specification:
 	// https://github.com/opencontainers/distribution-spec/blob/main/spec.md#error-codes
@@ -31,4 +33,23 @@ type Error struct {
 
 func (e Error) Error() string {
 	return e.Message
+}
+
+func NewErrorResponse(err ...Error) *ErrorResponse {
+	return &ErrorResponse{
+		Errors: err,
+	}
+}
+
+type ErrorResponse struct {
+	Errors []Error `json:"errors"`
+}
+
+func (e ErrorResponse) Error() string {
+	errs := make([]string, len(e.Errors))
+	for i := range e.Errors {
+		errs[i] = e.Errors[i].Error()
+	}
+
+	return strings.Join(errs, ", ")
 }

--- a/manifests_test.go
+++ b/manifests_test.go
@@ -7,52 +7,52 @@ import (
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/robinkb/cascade-registry"
+	. "github.com/robinkb/cascade-registry/testing"
 )
 
 func TestStatManifest(t *testing.T) {
 	service, metadata, blobs := newTestRegistry()
 
-	name := randomName()
-	manifest, _ := json.Marshal(v1.Manifest{MediaType: v1.MediaTypeImageLayer})
-	digest := digest.FromBytes(manifest)
+	name := RandomName()
+	digest, manifest := RandomManifest()
 
 	path := digest.String()
-	blobs.Put(path, manifest)
+	blobs.Put(path, manifest.Bytes())
 	metadata.PutManifest(name, digest, path)
 
 	t.Run("Returns FileInfo with expected size on known manifest", func(t *testing.T) {
 		info, err := service.StatManifest(name, digest.String())
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		got := info.Size
-		want := int64(len(manifest))
+		want := int64(len(manifest.Bytes()))
 
 		if got != want {
 			t.Errorf("got size of %d, expected %d", got, want)
 		}
-		assertNoError(t, err)
+		AssertNoError(t, err)
 	})
 
 	t.Run("Returns ErrManifestUnkonwn on known manifest in other repository", func(t *testing.T) {
 		_, err := service.StatManifest("unknown/repository", digest.String())
-		assertErrorIs(t, err, cascade.ErrManifestUnknown)
+		AssertErrorIs(t, err, cascade.ErrManifestUnknown)
 	})
 
 	t.Run("returns ErrManifestUnknown on unknown manifest", func(t *testing.T) {
 		_, err := service.StatManifest(name, "sha256:ce5449ab65895b60068d164e81b646753d268583a70895acee51e1d711ddf3a2")
-		assertErrorIs(t, err, cascade.ErrManifestUnknown)
+		AssertErrorIs(t, err, cascade.ErrManifestUnknown)
 	})
 
 	t.Run("returns ErrManifestUnknown on invalid digest", func(t *testing.T) {
 		_, err := service.StatManifest(name, "sha256:i-am-not-valid-lol")
-		assertErrorIs(t, err, cascade.ErrManifestUnknown)
+		AssertErrorIs(t, err, cascade.ErrManifestUnknown)
 	})
 }
 
 func TestGetManifest(t *testing.T) {
 	service, metadata, blobs := newTestRegistry()
 
-	name := randomName()
+	name := RandomName()
 	manifest, _ := json.Marshal(v1.Manifest{MediaType: v1.MediaTypeImageLayer})
 	digest := digest.FromBytes(manifest)
 
@@ -62,13 +62,13 @@ func TestGetManifest(t *testing.T) {
 
 	t.Run("Retrieve an existing manifest", func(t *testing.T) {
 		got, err := service.GetManifest(name, digest.String())
-		assertNoError(t, err)
-		assertContent(t, got.Bytes(), manifest)
+		AssertNoError(t, err)
+		AssertSlicesEqual(t, got.Bytes(), manifest)
 	})
 
 	t.Run("returns ErrManifestUnknown on unknown manifest", func(t *testing.T) {
 		_, err := service.GetManifest("i/do/not/exist", "sha256:ce5449ab65895b60068d164e81b646753d268583a70895acee51e1d711ddf3a2")
-		assertErrorIs(t, err, cascade.ErrManifestUnknown)
+		AssertErrorIs(t, err, cascade.ErrManifestUnknown)
 	})
 }
 
@@ -76,21 +76,23 @@ func TestPutManifest(t *testing.T) {
 	service, _, _ := newTestRegistry()
 
 	t.Run("Put and retrieve a manifest", func(t *testing.T) {
-		name, digest, manifest := randomManifest()
+		name := RandomName()
+		digest, manifest := RandomManifest()
 
-		err := service.PutManifest(name, digest.String(), manifest)
-		assertNoError(t, err)
+		err := service.PutManifest(name, digest.String(), manifest.Bytes())
+		AssertNoError(t, err)
 
 		got, err := service.GetManifest(name, digest.String())
-		assertNoError(t, err)
-		assertContent(t, got.Bytes(), manifest)
+		AssertNoError(t, err)
+		AssertSlicesEqual(t, got.Bytes(), manifest.Bytes())
 	})
 
 	t.Run("Putting a manifest with invalid content returns ErrManifestInvalid", func(t *testing.T) {
-		name, digest, content := randomBlob(32)
+		name := RandomName()
+		digest, content := RandomBlob(32)
 
 		err := service.PutManifest(name, digest.String(), content)
-		assertErrorIs(t, err, cascade.ErrManifestInvalid)
+		AssertErrorIs(t, err, cascade.ErrManifestInvalid)
 	})
 }
 
@@ -98,33 +100,24 @@ func TestDeleteManifest(t *testing.T) {
 	service, _, _ := newTestRegistry()
 
 	t.Run("Delete manifest and make sure it cannot be retrieved", func(t *testing.T) {
-		name, digest, manifest := randomManifest()
+		name := RandomName()
+		digest, manifest := RandomManifest()
 
-		err := service.PutManifest(name, digest.String(), manifest)
-		assertNoError(t, err)
+		err := service.PutManifest(name, digest.String(), manifest.Bytes())
+		RequireNoError(t, err)
 
 		_, err = service.StatManifest(name, digest.String())
-		assertNoError(t, err)
+		RequireNoError(t, err)
 
 		err = service.DeleteManifest(name, digest.String())
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		_, err = service.StatManifest(name, digest.String())
-		assertErrorIs(t, err, cascade.ErrManifestUnknown)
+		AssertErrorIs(t, err, cascade.ErrManifestUnknown)
 	})
 
 	t.Run("Deleting an unknown manifest returns ErrManifestUknown", func(t *testing.T) {
 		err := service.DeleteManifest("does/not/exist", "123")
-		assertErrorIs(t, err, cascade.ErrManifestUnknown)
+		AssertErrorIs(t, err, cascade.ErrManifestUnknown)
 	})
-}
-
-func randomManifest() (string, digest.Digest, []byte) {
-	name := randomName()
-	manifest, _ := json.Marshal(v1.Manifest{
-		MediaType: v1.MediaTypeImageLayer,
-	})
-	digest := digest.FromBytes(manifest)
-
-	return name, digest, manifest
 }

--- a/server/blob_uploads_test.go
+++ b/server/blob_uploads_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	"github.com/robinkb/cascade-registry"
+	. "github.com/robinkb/cascade-registry/testing"
 )
 
 func TestBlobUploadsMonolithic(t *testing.T) {
@@ -33,7 +34,7 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 
 	t.Run("Uploading without required headers returns 400", func(t *testing.T) {
 		server := New(&StubRegistryService{})
-		content := randomContents(32)
+		content := RandomContents(32)
 
 		request := newBlobUploadRequest("/v2/library/fedora/blobs/uploads/123", content)
 		request.Header.Del(headerContentType)

--- a/server/blob_uploads_test.go
+++ b/server/blob_uploads_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"github.com/opencontainers/go-digest"
@@ -28,8 +27,8 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusNotFound)
-		assertErrorInResponseBody(t, response.Body, cascade.ErrBlobUploadUnknown)
+		AssertResponseCode(t, response.Result(), http.StatusNotFound)
+		AssertResponseBodyContainsError(t, response.Result(), cascade.ErrBlobUploadUnknown)
 	})
 
 	t.Run("Uploading without required headers returns 400", func(t *testing.T) {
@@ -43,7 +42,7 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusBadRequest)
+		AssertResponseCode(t, response.Result(), http.StatusBadRequest)
 	})
 
 	t.Run("Closing upload without digest returns 400", func(t *testing.T) {
@@ -55,7 +54,7 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusBadRequest)
+		AssertResponseCode(t, response.Result(), http.StatusBadRequest)
 	})
 
 	t.Run("Closing upload with invalid digest returns 400", func(t *testing.T) {
@@ -69,8 +68,8 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusBadRequest)
-		assertErrorInResponseBody(t, response.Body, cascade.ErrDigestInvalid)
+		AssertResponseCode(t, response.Result(), http.StatusBadRequest)
+		AssertResponseBodyContainsError(t, response.Result(), cascade.ErrDigestInvalid)
 	})
 
 	t.Run("Uploading with wrong digest returns 400", func(t *testing.T) {
@@ -83,8 +82,8 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusBadRequest)
-		assertErrorInResponseBody(t, response.Body, cascade.ErrBlobUploadInvalid)
+		AssertResponseCode(t, response.Result(), http.StatusBadRequest)
+		AssertResponseBodyContainsError(t, response.Result(), cascade.ErrBlobUploadInvalid)
 	})
 }
 
@@ -113,28 +112,5 @@ func newBlobUploadRequest(location string, content []byte) *http.Request {
 
 func newCheckUploadRequest(location string) *http.Request {
 	req, _ := http.NewRequest(http.MethodGet, location, nil)
-	return req
-}
-
-func newUploadChunkRequest(location string, content []byte, written int) *http.Request {
-	size := len(content)
-	buf := bytes.NewBuffer(content)
-	req, _ := http.NewRequest(http.MethodPatch, location, buf)
-	req.Header.Set(headerContentType, contentTypeOctetStream)
-	req.Header.Set(headerContentRange, fmt.Sprintf("%d-%d", written, written+size-1))
-	req.Header.Set(headerContentLength, strconv.Itoa(size))
-	return req
-}
-
-func newCloseUploadRequest(location, digest string, content []byte) *http.Request {
-	body := bytes.NewBuffer(content)
-	req, _ := http.NewRequest(http.MethodPut, location, body)
-	if len(content) > 0 {
-		req.Header.Set(headerContentType, contentTypeOctetStream)
-		req.Header.Set(headerContentLength, strconv.Itoa(len(content)))
-	}
-	query := req.URL.Query()
-	query.Set("digest", digest)
-	req.URL.RawQuery = query.Encode()
 	return req
 }

--- a/server/blobs_test.go
+++ b/server/blobs_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/robinkb/cascade-registry"
+	. "github.com/robinkb/cascade-registry/testing"
 )
 
 func TestStatBlob(t *testing.T) {
@@ -29,7 +30,7 @@ func TestStatBlob(t *testing.T) {
 		server.ServeHTTP(response, request)
 		assertStatus(t, response.Code, http.StatusOK)
 		assertHeader(t, headerContentLength, response.Header(), strconv.Itoa(size))
-		assertResponseBody(t, response.Body.Bytes(), nil)
+		AssertResponseBodyEquals(t, response.Result(), nil)
 	})
 
 	t.Run("unknown blob returns 404", func(t *testing.T) {
@@ -50,7 +51,7 @@ func TestStatBlob(t *testing.T) {
 
 func TestGetBlob(t *testing.T) {
 	t.Run("Get blob returns 200", func(t *testing.T) {
-		content := randomContents(32)
+		content := RandomContents(32)
 		server := New(&StubRegistryService{
 			getBlob: func(repository, digest string) (io.Reader, error) {
 				return bytes.NewBuffer(content), nil
@@ -62,7 +63,7 @@ func TestGetBlob(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 		assertStatus(t, response.Code, http.StatusOK)
-		assertResponseBody(t, response.Body.Bytes(), content)
+		AssertResponseBodyEquals(t, response.Result(), content)
 	})
 
 	t.Run("returns 404 on unknown blob", func(t *testing.T) {
@@ -84,7 +85,9 @@ func TestGetBlob(t *testing.T) {
 
 func TestDeleteBlob(t *testing.T) {
 	t.Run("Delete blob returns 202", func(t *testing.T) {
-		name, id, _ := randomBlob(32)
+		name := RandomName()
+		id := RandomDigest()
+
 		server := New(&StubRegistryService{
 			deleteBlob: func(repository, digest string) error {
 				if repository != name || digest != id.String() {

--- a/server/blobs_test.go
+++ b/server/blobs_test.go
@@ -28,8 +28,8 @@ func TestStatBlob(t *testing.T) {
 		response := httptest.NewRecorder()
 
 		server.ServeHTTP(response, request)
-		assertStatus(t, response.Code, http.StatusOK)
-		assertHeader(t, headerContentLength, response.Header(), strconv.Itoa(size))
+		AssertResponseCode(t, response.Result(), http.StatusOK)
+		AssertResponseHeader(t, response.Result(), headerContentLength, strconv.Itoa(size))
 		AssertResponseBodyEquals(t, response.Result(), nil)
 	})
 
@@ -44,8 +44,8 @@ func TestStatBlob(t *testing.T) {
 		response := httptest.NewRecorder()
 
 		server.ServeHTTP(response, request)
-		assertStatus(t, response.Code, http.StatusNotFound)
-		assertErrorInResponseBody(t, response.Body, cascade.ErrBlobUnknown)
+		AssertResponseCode(t, response.Result(), http.StatusNotFound)
+		AssertResponseBodyContainsError(t, response.Result(), cascade.ErrBlobUnknown)
 	})
 }
 
@@ -62,7 +62,7 @@ func TestGetBlob(t *testing.T) {
 		response := httptest.NewRecorder()
 
 		server.ServeHTTP(response, request)
-		assertStatus(t, response.Code, http.StatusOK)
+		AssertResponseCode(t, response.Result(), http.StatusOK)
 		AssertResponseBodyEquals(t, response.Result(), content)
 	})
 
@@ -77,8 +77,9 @@ func TestGetBlob(t *testing.T) {
 		response := httptest.NewRecorder()
 
 		server.ServeHTTP(response, request)
-		assertStatus(t, response.Code, http.StatusNotFound)
-		assertErrorInResponseBody(t, response.Body, cascade.ErrBlobUnknown)
+
+		AssertResponseCode(t, response.Result(), http.StatusNotFound)
+		AssertResponseBodyContainsError(t, response.Result(), cascade.ErrBlobUnknown)
 	})
 
 }
@@ -102,7 +103,7 @@ func TestDeleteBlob(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusAccepted)
+		AssertResponseCode(t, response.Result(), http.StatusAccepted)
 	})
 }
 
@@ -115,7 +116,8 @@ func TestBlobsOthers(t *testing.T) {
 		response := httptest.NewRecorder()
 
 		server.ServeHTTP(response, request)
-		assertStatus(t, response.Code, http.StatusMethodNotAllowed)
+
+		AssertResponseCode(t, response.Result(), http.StatusMethodNotAllowed)
 	})
 }
 

--- a/server/manifests_test.go
+++ b/server/manifests_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/robinkb/cascade-registry"
+	. "github.com/robinkb/cascade-registry/testing"
 )
 
 func TestStatManifests(t *testing.T) {
@@ -31,7 +32,7 @@ func TestStatManifests(t *testing.T) {
 
 		assertStatus(t, response.Code, http.StatusOK)
 		assertHeader(t, headerContentLength, response.Header(), strconv.Itoa(len(manifest)))
-		assertResponseBody(t, response.Body.Bytes(), nil)
+		AssertResponseBodyEquals(t, response.Result(), nil)
 	})
 
 	t.Run("Stat existing manifest by tag returns 200 with correct size in Content-Length header", func(t *testing.T) {
@@ -59,7 +60,7 @@ func TestStatManifests(t *testing.T) {
 
 		assertStatus(t, response.Code, http.StatusOK)
 		assertHeader(t, headerContentLength, response.Header(), strconv.Itoa(len(manifest)))
-		assertResponseBody(t, response.Body.Bytes(), nil)
+		AssertResponseBodyEquals(t, response.Result(), nil)
 	})
 
 	t.Run("Stat non-existent manifest returns 404 and ErrManifestUknown", func(t *testing.T) {
@@ -109,7 +110,7 @@ func TestGetManifests(t *testing.T) {
 
 		assertStatus(t, response.Code, http.StatusOK)
 		assertHeader(t, headerContentType, response.Header(), v1.MediaTypeImageLayer)
-		assertResponseBody(t, response.Body.Bytes(), manifest)
+		AssertResponseBodyEquals(t, response.Result(), manifest)
 	})
 
 	t.Run("Retrieving a manifest by tag returns 200", func(t *testing.T) {
@@ -135,7 +136,7 @@ func TestGetManifests(t *testing.T) {
 		server.ServeHTTP(response, request)
 
 		assertStatus(t, response.Code, http.StatusOK)
-		assertResponseBody(t, response.Body.Bytes(), manifest)
+		AssertResponseBodyEquals(t, response.Result(), manifest)
 	})
 
 	t.Run("Retrieving a non-existent manifest returns status 404 and ErrManifestUnknown", func(t *testing.T) {
@@ -168,8 +169,8 @@ func TestPutManifest(t *testing.T) {
 		server.ServeHTTP(response, request)
 
 		assertStatus(t, response.Code, http.StatusCreated)
-		assertHeaderSet(t, headerLocation, response.Header())
-		assertResponseBody(t, response.Body.Bytes(), nil)
+		AssertResponseHeaderSet(t, response.Result(), headerLocation)
+		AssertResponseBodyEquals(t, response.Result(), nil)
 	})
 
 	t.Run("Uploading a manifest by tag returns code 201", func(t *testing.T) {
@@ -202,8 +203,8 @@ func TestPutManifest(t *testing.T) {
 		}
 
 		assertStatus(t, response.Code, http.StatusCreated)
-		assertHeaderSet(t, headerLocation, response.Header())
-		assertResponseBody(t, response.Body.Bytes(), nil)
+		AssertResponseHeaderSet(t, response.Result(), headerLocation)
+		AssertResponseBodyEquals(t, response.Result(), nil)
 	})
 
 	t.Run("Uploading an invalid manifest returns 400 and ErrManifestInvalid", func(t *testing.T) {
@@ -240,7 +241,7 @@ func TestDeleteManifest(t *testing.T) {
 	})
 
 	t.Run("Deleting a manifest by tag returns 202", func(t *testing.T) {
-		name, wantTag := randomName(), "v4.2.3"
+		name, wantTag := RandomName(), "v4.2.3"
 		deleteTagCalled := false
 		server := New(&StubRegistryService{deleteTag: func(repository, tag string) error {
 			if repository == name && tag == wantTag {
@@ -310,7 +311,7 @@ func newDeleteManifestRequest(name, reference string) *http.Request {
 }
 
 func randomManifest() (string, digest.Digest, []byte) {
-	name := randomName()
+	name := RandomName()
 	manifest, _ := json.Marshal(v1.Manifest{
 		MediaType: v1.MediaTypeImageLayer,
 	})

--- a/server/manifests_test.go
+++ b/server/manifests_test.go
@@ -30,8 +30,8 @@ func TestStatManifests(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusOK)
-		assertHeader(t, headerContentLength, response.Header(), strconv.Itoa(len(manifest)))
+		AssertResponseCode(t, response.Result(), http.StatusOK)
+		AssertResponseHeader(t, response.Result(), headerContentLength, strconv.Itoa(len(manifest)))
 		AssertResponseBodyEquals(t, response.Result(), nil)
 	})
 
@@ -58,8 +58,8 @@ func TestStatManifests(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusOK)
-		assertHeader(t, headerContentLength, response.Header(), strconv.Itoa(len(manifest)))
+		AssertResponseCode(t, response.Result(), http.StatusOK)
+		AssertResponseHeader(t, response.Result(), headerContentLength, strconv.Itoa(len(manifest)))
 		AssertResponseBodyEquals(t, response.Result(), nil)
 	})
 
@@ -73,8 +73,8 @@ func TestStatManifests(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusNotFound)
-		assertErrorInResponseBody(t, response.Body, cascade.ErrManifestUnknown)
+		AssertResponseCode(t, response.Result(), http.StatusNotFound)
+		AssertResponseBodyContainsError(t, response.Result(), cascade.ErrManifestUnknown)
 	})
 
 	t.Run("Stat non-existent manifest by tag returns 404 and ErrManifestUknown", func(t *testing.T) {
@@ -87,8 +87,8 @@ func TestStatManifests(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusNotFound)
-		assertErrorInResponseBody(t, response.Body, cascade.ErrManifestUnknown)
+		AssertResponseCode(t, response.Result(), http.StatusNotFound)
+		AssertResponseBodyContainsError(t, response.Result(), cascade.ErrManifestUnknown)
 	})
 }
 
@@ -108,8 +108,8 @@ func TestGetManifests(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusOK)
-		assertHeader(t, headerContentType, response.Header(), v1.MediaTypeImageLayer)
+		AssertResponseCode(t, response.Result(), http.StatusOK)
+		AssertResponseHeader(t, response.Result(), headerContentType, v1.MediaTypeImageLayer)
 		AssertResponseBodyEquals(t, response.Result(), manifest)
 	})
 
@@ -135,7 +135,7 @@ func TestGetManifests(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusOK)
+		AssertResponseCode(t, response.Result(), http.StatusOK)
 		AssertResponseBodyEquals(t, response.Result(), manifest)
 	})
 
@@ -148,8 +148,8 @@ func TestGetManifests(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusNotFound)
-		assertErrorInResponseBody(t, response.Body, cascade.ErrManifestUnknown)
+		AssertResponseCode(t, response.Result(), http.StatusNotFound)
+		AssertResponseBodyContainsError(t, response.Result(), cascade.ErrManifestUnknown)
 	})
 }
 
@@ -168,7 +168,7 @@ func TestPutManifest(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusCreated)
+		AssertResponseCode(t, response.Result(), http.StatusCreated)
 		AssertResponseHeaderSet(t, response.Result(), headerLocation)
 		AssertResponseBodyEquals(t, response.Result(), nil)
 	})
@@ -202,7 +202,7 @@ func TestPutManifest(t *testing.T) {
 			t.Error("service.PutTag was never called")
 		}
 
-		assertStatus(t, response.Code, http.StatusCreated)
+		AssertResponseCode(t, response.Result(), http.StatusCreated)
 		AssertResponseHeaderSet(t, response.Result(), headerLocation)
 		AssertResponseBodyEquals(t, response.Result(), nil)
 	})
@@ -217,14 +217,15 @@ func TestPutManifest(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusBadRequest)
-		assertErrorInResponseBody(t, response.Body, cascade.ErrManifestInvalid)
+		AssertResponseCode(t, response.Result(), http.StatusBadRequest)
+		AssertResponseBodyContainsError(t, response.Result(), cascade.ErrManifestInvalid)
 	})
 }
 
 func TestDeleteManifest(t *testing.T) {
 	t.Run("Deleting a manifest returns code 202", func(t *testing.T) {
-		name, digest, _ := randomManifest()
+		name := RandomName()
+		digest := RandomDigest()
 		server := New(&StubRegistryService{deleteManifest: func(repository, reference string) error {
 			if repository == name && reference == digest.String() {
 				return nil
@@ -237,7 +238,7 @@ func TestDeleteManifest(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusAccepted)
+		AssertResponseCode(t, response.Result(), http.StatusAccepted)
 	})
 
 	t.Run("Deleting a manifest by tag returns 202", func(t *testing.T) {
@@ -256,7 +257,7 @@ func TestDeleteManifest(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusAccepted)
+		AssertResponseCode(t, response.Result(), http.StatusAccepted)
 		if !deleteTagCalled {
 			t.Error("DeleteTag was not called")
 		}
@@ -272,8 +273,8 @@ func TestDeleteManifest(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusNotFound)
-		assertErrorInResponseBody(t, response.Body, cascade.ErrManifestUnknown)
+		AssertResponseCode(t, response.Result(), http.StatusNotFound)
+		AssertResponseBodyContainsError(t, response.Result(), cascade.ErrManifestUnknown)
 	})
 }
 
@@ -286,7 +287,7 @@ func TestManifestsOthers(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusMethodNotAllowed)
+		AssertResponseCode(t, response.Result(), http.StatusMethodNotAllowed)
 	})
 }
 

--- a/server/manifests_test.go
+++ b/server/manifests_test.go
@@ -2,14 +2,12 @@ package server
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"testing"
 
-	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/robinkb/cascade-registry"
 	. "github.com/robinkb/cascade-registry/testing"
@@ -17,10 +15,11 @@ import (
 
 func TestStatManifests(t *testing.T) {
 	t.Run("Stat existing manifest returns 200 with correct size in Content-Length header", func(t *testing.T) {
-		name, digest, manifest := randomManifest()
+		name := RandomName()
+		digest, manifest := RandomManifest()
 		server := New(&StubRegistryService{statManifest: func(repository, reference string) (*cascade.FileInfo, error) {
 			if repository == name && reference == digest.String() {
-				return &cascade.FileInfo{Size: int64(len(manifest))}, nil
+				return &cascade.FileInfo{Size: int64(len(manifest.Bytes()))}, nil
 			}
 			panic(errDataNotPassedCorrectly)
 		}})
@@ -31,13 +30,14 @@ func TestStatManifests(t *testing.T) {
 		server.ServeHTTP(response, request)
 
 		AssertResponseCode(t, response.Result(), http.StatusOK)
-		AssertResponseHeader(t, response.Result(), headerContentLength, strconv.Itoa(len(manifest)))
+		AssertResponseHeader(t, response.Result(), headerContentLength, strconv.Itoa(len(manifest.Bytes())))
 		AssertResponseBodyEquals(t, response.Result(), nil)
 	})
 
 	t.Run("Stat existing manifest by tag returns 200 with correct size in Content-Length header", func(t *testing.T) {
 		wantTag := "v0.9.1"
-		name, digest, manifest := randomManifest()
+		name := RandomName()
+		digest, manifest := RandomManifest()
 		server := New(&StubRegistryService{
 			getTag: func(repository, tag string) (string, error) {
 				if repository == name && tag == wantTag {
@@ -47,7 +47,7 @@ func TestStatManifests(t *testing.T) {
 			},
 			statManifest: func(repository, reference string) (*cascade.FileInfo, error) {
 				if repository == name && reference == digest.String() {
-					return &cascade.FileInfo{Size: int64(len(manifest))}, nil
+					return &cascade.FileInfo{Size: int64(len(manifest.Bytes()))}, nil
 				}
 				panic(errDataNotPassedCorrectly)
 			},
@@ -59,7 +59,7 @@ func TestStatManifests(t *testing.T) {
 		server.ServeHTTP(response, request)
 
 		AssertResponseCode(t, response.Result(), http.StatusOK)
-		AssertResponseHeader(t, response.Result(), headerContentLength, strconv.Itoa(len(manifest)))
+		AssertResponseHeader(t, response.Result(), headerContentLength, strconv.Itoa(len(manifest.Bytes())))
 		AssertResponseBodyEquals(t, response.Result(), nil)
 	})
 
@@ -93,12 +93,13 @@ func TestStatManifests(t *testing.T) {
 }
 
 func TestGetManifests(t *testing.T) {
-	name, digest, manifest := randomManifest()
+	name := RandomName()
+	digest, manifest := RandomManifest()
 
 	t.Run("Retrieving an existing manifest returns 200", func(t *testing.T) {
 		server := New(&StubRegistryService{getManifest: func(repository, reference string) (*cascade.Manifest, error) {
 			if repository == name && reference == digest.String() {
-				return cascade.NewManifest(manifest)
+				return cascade.NewManifest(manifest.Bytes())
 			}
 			panic(errDataNotPassedCorrectly)
 		}})
@@ -110,7 +111,7 @@ func TestGetManifests(t *testing.T) {
 
 		AssertResponseCode(t, response.Result(), http.StatusOK)
 		AssertResponseHeader(t, response.Result(), headerContentType, v1.MediaTypeImageLayer)
-		AssertResponseBodyEquals(t, response.Result(), manifest)
+		AssertResponseBodyEquals(t, response.Result(), manifest.Bytes())
 	})
 
 	t.Run("Retrieving a manifest by tag returns 200", func(t *testing.T) {
@@ -124,7 +125,7 @@ func TestGetManifests(t *testing.T) {
 			},
 			getManifest: func(repository, reference string) (*cascade.Manifest, error) {
 				if repository == name && reference == digest.String() {
-					return cascade.NewManifest(manifest)
+					return cascade.NewManifest(manifest.Bytes())
 				}
 				panic(errDataNotPassedCorrectly)
 			},
@@ -136,7 +137,7 @@ func TestGetManifests(t *testing.T) {
 		server.ServeHTTP(response, request)
 
 		AssertResponseCode(t, response.Result(), http.StatusOK)
-		AssertResponseBodyEquals(t, response.Result(), manifest)
+		AssertResponseBodyEquals(t, response.Result(), manifest.Bytes())
 	})
 
 	t.Run("Retrieving a non-existent manifest returns status 404 and ErrManifestUnknown", func(t *testing.T) {
@@ -155,15 +156,16 @@ func TestGetManifests(t *testing.T) {
 
 func TestPutManifest(t *testing.T) {
 	t.Run("Uploading a manifest by digest returns code 201", func(t *testing.T) {
-		name, digest, manifest := randomManifest()
+		name := RandomName()
+		digest, manifest := RandomManifest()
 		server := New(&StubRegistryService{putManifest: func(repository, reference string, content []byte) error {
-			if repository == name && reference == digest.String() && bytes.Equal(content, manifest) {
+			if repository == name && reference == digest.String() && bytes.Equal(content, manifest.Bytes()) {
 				return nil
 			}
 			panic(errDataNotPassedCorrectly)
 		}})
 
-		request := newPutManifestRequest(name, digest.String(), manifest)
+		request := newPutManifestRequest(name, digest.String(), manifest.Bytes())
 		response := httptest.NewRecorder()
 
 		server.ServeHTTP(response, request)
@@ -176,7 +178,8 @@ func TestPutManifest(t *testing.T) {
 	t.Run("Uploading a manifest by tag returns code 201", func(t *testing.T) {
 		wantTag := "0.4.2"
 		putTagCalled := false
-		name, digest, manifest := randomManifest()
+		name := RandomName()
+		digest, manifest := RandomManifest()
 		server := New(&StubRegistryService{
 			putTag: func(repository, tag, id string) error {
 				if repository == name && tag == wantTag && id == digest.String() {
@@ -186,14 +189,14 @@ func TestPutManifest(t *testing.T) {
 				panic(errDataNotPassedCorrectly)
 			},
 			putManifest: func(repository, reference string, content []byte) error {
-				if repository == name && reference == digest.String() && bytes.Equal(content, manifest) {
+				if repository == name && reference == digest.String() && bytes.Equal(content, manifest.Bytes()) {
 					return nil
 				}
 				panic(errDataNotPassedCorrectly)
 			},
 		})
 
-		request := newPutManifestRequest(name, wantTag, manifest)
+		request := newPutManifestRequest(name, wantTag, manifest.Bytes())
 		response := httptest.NewRecorder()
 
 		server.ServeHTTP(response, request)
@@ -309,14 +312,4 @@ func newPutManifestRequest(name, reference string, body []byte) *http.Request {
 func newDeleteManifestRequest(name, reference string) *http.Request {
 	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("/v2/%s/manifests/%s", name, reference), nil)
 	return req
-}
-
-func randomManifest() (string, digest.Digest, []byte) {
-	name := RandomName()
-	manifest, _ := json.Marshal(v1.Manifest{
-		MediaType: v1.MediaTypeImageLayer,
-	})
-	digest := digest.FromBytes(manifest)
-
-	return name, digest, manifest
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,8 +1,6 @@
 package server
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"io"
 
@@ -95,7 +93,7 @@ func TestRoot(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusOK)
+		AssertResponseCode(t, response.Result(), http.StatusOK)
 	})
 }
 
@@ -106,40 +104,4 @@ func newTestServer() *Server {
 			inmemory.NewBlobStore(),
 		),
 	)
-}
-
-func assertErrorInResponseBody(t *testing.T, body *bytes.Buffer, want cascade.Error) {
-	t.Helper()
-
-	var errs ErrorResponse
-	err := json.NewDecoder(body).Decode(&errs)
-	AssertNoError(t, err)
-
-	for _, err := range errs.Errors {
-		if errors.Is(err, want) {
-			return
-		}
-	}
-
-	t.Errorf("could not find error in response; got %v, want %v", body, want)
-}
-
-func assertStatus(t *testing.T, got, want int) {
-	t.Helper()
-	if got != want {
-		t.Errorf("got status %d, want %d", got, want)
-	}
-}
-
-func assertHeader(t *testing.T, header string, got http.Header, want string) {
-	t.Helper()
-	val := got.Get(header)
-	if val == "" {
-		t.Errorf("Header '%s' not set", header)
-		return
-	}
-
-	if val != want {
-		t.Errorf("Header '%s' set to %q, want %q", header, val, want)
-	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2,21 +2,17 @@ package server
 
 import (
 	"bytes"
-	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"io"
-	"strings"
 
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 
-	"github.com/moby/moby/pkg/namesgenerator"
-	"github.com/opencontainers/go-digest"
 	"github.com/robinkb/cascade-registry"
 	"github.com/robinkb/cascade-registry/store/inmemory"
+	. "github.com/robinkb/cascade-registry/testing"
 )
 
 var (
@@ -112,20 +108,12 @@ func newTestServer() *Server {
 	)
 }
 
-func assertNoError(t *testing.T, err error) {
-	t.Helper()
-	if err != nil {
-		t.Errorf("got error where none was expected: %v", err)
-		t.FailNow()
-	}
-}
-
 func assertErrorInResponseBody(t *testing.T, body *bytes.Buffer, want cascade.Error) {
 	t.Helper()
 
 	var errs ErrorResponse
 	err := json.NewDecoder(body).Decode(&errs)
-	assertNoError(t, err)
+	AssertNoError(t, err)
 
 	for _, err := range errs.Errors {
 		if errors.Is(err, want) {
@@ -154,35 +142,4 @@ func assertHeader(t *testing.T, header string, got http.Header, want string) {
 	if val != want {
 		t.Errorf("Header '%s' set to %q, want %q", header, val, want)
 	}
-}
-
-func assertHeaderSet(t *testing.T, header string, got http.Header) {
-	t.Helper()
-	if got.Get(header) == "" {
-		t.Errorf("Header '%s' not set", header)
-	}
-}
-
-func assertResponseBody(t *testing.T, got, want []byte) {
-	t.Helper()
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("response body did not match the expected content")
-	}
-}
-
-func randomBlob(length int64) (name string, id digest.Digest, content []byte) {
-	name = randomName()
-	content = randomContents(length)
-	id = digest.FromBytes(content)
-	return
-}
-
-func randomName() string {
-	return strings.Replace(namesgenerator.GetRandomName(0), "_", "/", -1)
-}
-
-func randomContents(length int64) []byte {
-	data := make([]byte, length)
-	rand.Read(data)
-	return data
 }

--- a/server/tags_test.go
+++ b/server/tags_test.go
@@ -8,11 +8,13 @@ import (
 	"slices"
 	"strconv"
 	"testing"
+
+	. "github.com/robinkb/cascade-registry/testing"
 )
 
 func TestListTags(t *testing.T) {
 	t.Run("Listing tags returns 200", func(t *testing.T) {
-		wantName := randomName()
+		wantName := RandomName()
 		wantTags := []string{"40", "1.2.3", "latest"}
 		server := New(&StubRegistryService{listTags: func(repository string, count int, last string) ([]string, error) {
 			if repository == wantName && count == -1 && last == "" {
@@ -30,7 +32,7 @@ func TestListTags(t *testing.T) {
 
 		var tagsList TagsListResponse
 		err := json.Unmarshal(response.Body.Bytes(), &tagsList)
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		gotName := tagsList.Name
 		gotTags := tagsList.Tags
@@ -45,7 +47,7 @@ func TestListTags(t *testing.T) {
 	})
 
 	t.Run("n and last query parameters are handled correctly", func(t *testing.T) {
-		wantName := randomName()
+		wantName := RandomName()
 		wantCount := 3
 		wantLast := "40"
 

--- a/server/tags_test.go
+++ b/server/tags_test.go
@@ -28,7 +28,7 @@ func TestListTags(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusOK)
+		AssertResponseCode(t, response.Result(), http.StatusOK)
 
 		var tagsList TagsListResponse
 		err := json.Unmarshal(response.Body.Bytes(), &tagsList)
@@ -68,6 +68,6 @@ func TestListTags(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusOK)
+		AssertResponseCode(t, response.Result(), http.StatusOK)
 	})
 }

--- a/server/upload_sessions_test.go
+++ b/server/upload_sessions_test.go
@@ -21,7 +21,7 @@ func TestBlobUploadSession(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusAccepted)
+		AssertResponseCode(t, response.Result(), http.StatusAccepted)
 		AssertResponseHeaderSet(t, response.Result(), headerLocation)
 
 		location := response.Header().Get(headerLocation)
@@ -31,9 +31,9 @@ func TestBlobUploadSession(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusNoContent)
-		assertHeader(t, headerLocation, response.Header(), location)
-		assertHeader(t, headerRange, response.Header(), "0-0")
+		AssertResponseCode(t, response.Result(), http.StatusNoContent)
+		AssertResponseHeader(t, response.Result(), headerLocation, location)
+		AssertResponseHeader(t, response.Result(), headerRange, "0-0")
 	})
 
 	t.Run("Checking status of an unknown upload session returns 404 and ErrBlobUploadUnknown", func(t *testing.T) {
@@ -42,8 +42,8 @@ func TestBlobUploadSession(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusNotFound)
-		assertErrorInResponseBody(t, response.Body, cascade.ErrBlobUploadUnknown)
+		AssertResponseCode(t, response.Result(), http.StatusNotFound)
+		AssertResponseBodyContainsError(t, response.Result(), cascade.ErrBlobUploadUnknown)
 	})
 
 	t.Run("Upload session status with some content written returns correct Range header", func(t *testing.T) {
@@ -52,8 +52,7 @@ func TestBlobUploadSession(t *testing.T) {
 
 		server.ServeHTTP(response, request)
 
-		assertStatus(t, response.Code, http.StatusAccepted)
-
+		AssertResponseCode(t, response.Result(), http.StatusAccepted)
 	})
 }
 

--- a/server/upload_sessions_test.go
+++ b/server/upload_sessions_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/robinkb/cascade-registry"
+	. "github.com/robinkb/cascade-registry/testing"
 )
 
 func TestBlobUploadSession(t *testing.T) {
@@ -21,7 +22,7 @@ func TestBlobUploadSession(t *testing.T) {
 		server.ServeHTTP(response, request)
 
 		assertStatus(t, response.Code, http.StatusAccepted)
-		assertHeaderSet(t, headerLocation, response.Header())
+		AssertResponseHeaderSet(t, response.Result(), headerLocation)
 
 		location := response.Header().Get(headerLocation)
 

--- a/service_test.go
+++ b/service_test.go
@@ -1,14 +1,6 @@
 package cascade_test
 
 import (
-	"bytes"
-	"crypto/rand"
-	"errors"
-	"strings"
-	"testing"
-
-	"github.com/moby/moby/pkg/namesgenerator"
-	"github.com/opencontainers/go-digest"
 	"github.com/robinkb/cascade-registry"
 	"github.com/robinkb/cascade-registry/store/inmemory"
 )
@@ -19,43 +11,4 @@ func newTestRegistry() (cascade.RegistryService, cascade.MetadataStore, cascade.
 	service := cascade.NewRegistryService(metadata, blobs)
 
 	return service, metadata, blobs
-}
-
-func assertNoError(t *testing.T, err error) {
-	t.Helper()
-	if err != nil {
-		t.Errorf("got error where none was expected: %v", err)
-		t.FailNow()
-	}
-}
-
-func assertErrorIs(t *testing.T, got, want error) {
-	t.Helper()
-	if !errors.Is(got, want) {
-		t.Errorf("unexpected error: got %q, want %q", got, want)
-	}
-}
-
-func assertContent(t *testing.T, got, want []byte) {
-	t.Helper()
-	if !bytes.Equal(got, want) {
-		t.Errorf("expected contents to be equal")
-	}
-}
-
-func randomBlob(length int64) (name string, id digest.Digest, content []byte) {
-	name = randomName()
-	content = randomContents(length)
-	id = digest.FromBytes(content)
-	return
-}
-
-func randomName() string {
-	return strings.Replace(namesgenerator.GetRandomName(0), "_", "/", -1)
-}
-
-func randomContents(length int64) []byte {
-	data := make([]byte, length)
-	rand.Read(data)
-	return data
 }

--- a/tags_test.go
+++ b/tags_test.go
@@ -1,25 +1,25 @@
 package cascade_test
 
 import (
-	"fmt"
-	"math/rand/v2"
 	"slices"
 	"testing"
 
 	"github.com/robinkb/cascade-registry"
+	. "github.com/robinkb/cascade-registry/testing"
 )
 
 func TestGetTag(t *testing.T) {
 	service, metadata, _ := newTestRegistry()
 
 	t.Run("Manifest digest is retrievable by tag", func(t *testing.T) {
-		name, digest, _ := randomManifest()
+		name := RandomName()
+		digest := RandomDigest()
 		tag := "v1.2.3"
 
 		metadata.PutTag(name, tag, digest.String())
 
 		got, err := service.GetTag(name, tag)
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		if got != digest.String() {
 			t.Errorf("wrong digest retrieved; got %s, want %s", got, digest.String())
@@ -27,8 +27,8 @@ func TestGetTag(t *testing.T) {
 	})
 
 	t.Run("Unknown tag returns ErrManifestUnknown", func(t *testing.T) {
-		_, err := service.GetTag("non/existant", "v1.2.3")
-		assertErrorIs(t, err, cascade.ErrManifestUnknown)
+		_, err := service.GetTag("non/existent", "v1.2.3")
+		AssertErrorIs(t, err, cascade.ErrManifestUnknown)
 	})
 }
 
@@ -36,22 +36,23 @@ func TestPutTag(t *testing.T) {
 	service, _, _ := newTestRegistry()
 
 	t.Run("Tag creates a link to the manifest digest", func(t *testing.T) {
-		name, digest, manifest := randomManifest()
+		name := RandomName()
+		digest, manifest := RandomManifest()
 		tag := "v0.5.1"
 
-		err := service.PutManifest(name, digest.String(), manifest)
-		assertNoError(t, err)
+		err := service.PutManifest(name, digest.String(), manifest.Bytes())
+		AssertNoError(t, err)
 
 		err = service.PutTag(name, tag, digest.String())
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		gotDigest, err := service.GetTag(name, tag)
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		gotManifest, err := service.GetManifest(name, gotDigest)
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
-		assertContent(t, gotManifest.Bytes(), manifest)
+		AssertSlicesEqual(t, gotManifest.Bytes(), manifest.Bytes())
 	})
 }
 
@@ -59,20 +60,21 @@ func TestDeleteTag(t *testing.T) {
 	service, _, _ := newTestRegistry()
 
 	t.Run("Deleted tag is not retrievable", func(t *testing.T) {
-		name, digest, _ := randomManifest()
+		name := RandomName()
+		digest := RandomDigest()
 		tag := "v0.5.1"
 
 		err := service.PutTag(name, tag, digest.String())
-		assertNoError(t, err)
+		RequireNoError(t, err)
 
 		_, err = service.GetTag(name, tag)
-		assertNoError(t, err)
+		RequireNoError(t, err)
 
 		err = service.DeleteTag(name, tag)
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		_, err = service.GetTag(name, tag)
-		assertErrorIs(t, err, cascade.ErrManifestUnknown)
+		AssertErrorIs(t, err, cascade.ErrManifestUnknown)
 	})
 }
 
@@ -80,7 +82,8 @@ func TestListTag(t *testing.T) {
 	service, _, _ := newTestRegistry()
 
 	t.Run("Listing tags returns all in lexical order", func(t *testing.T) {
-		name, digest, _ := randomManifest()
+		name := RandomName()
+		digest := RandomDigest()
 		tags := []string{
 			"v1.0.0",
 			"v1.1.0",
@@ -90,11 +93,11 @@ func TestListTag(t *testing.T) {
 
 		for _, tag := range tags {
 			err := service.PutTag(name, tag, string(digest))
-			assertNoError(t, err)
+			RequireNoError(t, err)
 		}
 
 		got, err := service.ListTags(name, -1, "")
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		want := tags
 
@@ -104,17 +107,18 @@ func TestListTag(t *testing.T) {
 	})
 
 	t.Run("Listing tags with a count limit returns fewer tags", func(t *testing.T) {
-		name, digest, _ := randomManifest()
-		tags := randomTags(20)
+		name := RandomName()
+		digest := RandomDigest()
+		tags := RandomTags(20)
 		count := 5
 
 		for _, tag := range tags {
 			err := service.PutTag(name, tag, digest.String())
-			assertNoError(t, err)
+			RequireNoError(t, err)
 		}
 
 		got, err := service.ListTags(name, count, "")
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		want := tags[0:count]
 
@@ -124,17 +128,18 @@ func TestListTag(t *testing.T) {
 	})
 
 	t.Run("Listing tags with a count of 0 must return an empty list", func(t *testing.T) {
-		name, digest, _ := randomManifest()
-		tags := randomTags(5)
+		name := RandomName()
+		digest := RandomDigest()
+		tags := RandomTags(5)
 		count := 0
 
 		for _, tag := range tags {
 			err := service.PutTag(name, tag, digest.String())
-			assertNoError(t, err)
+			RequireNoError(t, err)
 		}
 
 		got, err := service.ListTags(name, count, "")
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		if len(got) != count {
 			t.Fatal("List tags with count of 0 returned a non-empty list")
@@ -142,17 +147,18 @@ func TestListTag(t *testing.T) {
 	})
 
 	t.Run("Listing tags with a count greater than the number of tags returns all tags", func(t *testing.T) {
-		name, digest, _ := randomManifest()
-		tags := randomTags(5)
+		name := RandomName()
+		digest := RandomDigest()
+		tags := RandomTags(5)
 		count := 6
 
 		for _, tag := range tags {
 			err := service.PutTag(name, tag, digest.String())
-			assertNoError(t, err)
+			RequireNoError(t, err)
 		}
 
 		got, err := service.ListTags(name, count, "")
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		if !slices.Equal(got, tags) {
 			t.Fatalf("Returned tags is not equal to actual tags; got %q, want %q", got, tags)
@@ -160,18 +166,19 @@ func TestListTag(t *testing.T) {
 	})
 
 	t.Run("Listing tags from a certain tag only returns tags after that tag", func(t *testing.T) {
-		name, digest, _ := randomManifest()
-		tags := randomTags(10)
+		name := RandomName()
+		digest := RandomDigest()
+		tags := RandomTags(10)
 		count := 3
 		last := 4
 
 		for _, tag := range tags {
 			err := service.PutTag(name, tag, digest.String())
-			assertNoError(t, err)
+			RequireNoError(t, err)
 		}
 
 		got, err := service.ListTags(name, count, tags[last])
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		want := tags[last+1 : last+1+count]
 
@@ -181,18 +188,19 @@ func TestListTag(t *testing.T) {
 	})
 
 	t.Run("When listing tags from a certain tag, the count parameter may be -1 to return all tags", func(t *testing.T) {
-		name, digest, _ := randomManifest()
-		tags := randomTags(10)
+		name := RandomName()
+		digest := RandomDigest()
+		tags := RandomTags(10)
 		count := -1
 		last := 4
 
 		for _, tag := range tags {
 			err := service.PutTag(name, tag, digest.String())
-			assertNoError(t, err)
+			RequireNoError(t, err)
 		}
 
 		got, err := service.ListTags(name, count, tags[last])
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		want := tags[last+1:]
 
@@ -200,16 +208,4 @@ func TestListTag(t *testing.T) {
 			t.Fatalf("Unexpected subset of tags; last %q, got %q, want %q", tags[last], got, want)
 		}
 	})
-}
-
-func randomTags(count int) (tags []string) {
-	for range count {
-		tags = append(tags, fmt.Sprintf("v%d.%d.%d",
-			rand.IntN(100), rand.IntN(100), rand.IntN(100),
-		))
-	}
-
-	slices.Sort(tags)
-
-	return
 }

--- a/testing/assert.go
+++ b/testing/assert.go
@@ -3,12 +3,23 @@ package testing
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"slices"
 	"testing"
 )
+
+func AssertErrorIs(t *testing.T, got, want error) bool {
+	t.Helper()
+
+	if !errors.Is(got, want) {
+		t.Errorf("unexpected error: got %q, want %q", got, want)
+		return false
+	}
+	return true
+}
 
 func AssertNoError(t *testing.T, got error) bool {
 	t.Helper()
@@ -20,7 +31,7 @@ func AssertNoError(t *testing.T, got error) bool {
 	return true
 }
 
-func AssertResponseCode(t *testing.T, got *http.Response, want int) {
+func AssertResponseCode(t *testing.T, got *http.Response, want int) bool {
 	t.Helper()
 
 	if got.StatusCode != want {
@@ -28,70 +39,84 @@ func AssertResponseCode(t *testing.T, got *http.Response, want int) {
 			httpStatusText(got.StatusCode),
 			httpStatusText(want),
 		)
+		return false
 	}
+	return true
 }
 
-func AssertResponseHeader(t *testing.T, got *http.Response, header string, want ...string) {
+func AssertResponseHeader(t *testing.T, got *http.Response, header string, want ...string) bool {
 	t.Helper()
 
 	val, ok := got.Header[header]
 	if !ok {
 		t.Errorf("header %q is not set", header)
-		return
+		return false
 	}
 
 	if !slices.Equal(val, want) {
 		t.Errorf("unexpected value for header %q; got %q, want %q", header, val, want)
+		return false
 	}
+	return true
 }
 
-func AssertResponseHeaderUnset(t *testing.T, got *http.Response, header string) {
+func AssertResponseHeaderUnset(t *testing.T, got *http.Response, header string) bool {
 	t.Helper()
 
 	_, ok := got.Header[header]
 	if ok {
 		t.Errorf("header %q is set", header)
+		return false
 	}
+	return true
 }
 
-func AssertResponseBodyEquals(t *testing.T, got *http.Response, want []byte) {
+func AssertResponseBodyEquals(t *testing.T, got *http.Response, want []byte) bool {
 	t.Helper()
 
 	data, err := io.ReadAll(got.Body)
 	if err != nil {
 		t.Fatalf("unexpected error while reading response body: %s", err)
+		return false
 	}
 
 	if !bytes.Equal(data, want) {
 		t.Errorf("request did not return the expected content")
+		return false
 	}
+	return true
 }
 
-func AssertResponseBodyUnmarshals[T any](t *testing.T, got *http.Response, obj T) {
+func AssertResponseBodyUnmarshals[T any](t *testing.T, got *http.Response, obj T) bool {
 	t.Helper()
 
 	data, err := io.ReadAll(got.Body)
 	if err != nil {
 		t.Fatalf("unexpected error while reading response body: %s", err)
+		return false
 	}
 
 	err = json.Unmarshal(data, obj)
 	if err != nil {
 		t.Errorf("could not unmarshal response body as %T: %s", obj, err)
+		return false
 	}
+	return true
 }
 
-func AssertSlicesEqual[S ~[]E, E comparable](t *testing.T, s1 S, s2 S) {
+func AssertSlicesEqual[S ~[]E, E comparable](t *testing.T, s1 S, s2 S) bool {
 	t.Helper()
 
 	if len(s1) != len(s2) {
 		t.Errorf("slices are of unequal length; got %d, want %d", len(s2), len(s1))
-		return
+		return false
 	}
 
 	if !slices.Equal(s1, s2) {
 		t.Errorf("slices are not equal; got %v, want %v", s2, s1)
+		return false
 	}
+	return true
 }
 
 func httpStatusText(code int) string {

--- a/testing/assert.go
+++ b/testing/assert.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"slices"
 	"testing"
+
+	"github.com/robinkb/cascade-registry"
 )
 
 func AssertErrorIs(t *testing.T, got, want error) bool {
@@ -112,6 +114,22 @@ func AssertResponseBodyUnmarshals[T any](t *testing.T, got *http.Response, obj T
 		t.Errorf("could not unmarshal response body as %T: %s", obj, err)
 		return false
 	}
+	return true
+}
+
+func AssertResponseBodyContainsError(t *testing.T, got *http.Response, want cascade.Error) bool {
+	t.Helper()
+
+	var errs cascade.ErrorResponse
+	err := json.NewDecoder(got.Body).Decode(&errs)
+	RequireNoError(t, err)
+
+	for _, err := range errs.Errors {
+		if errors.Is(err, want) {
+			return true
+		}
+	}
+
 	return true
 }
 

--- a/testing/assert.go
+++ b/testing/assert.go
@@ -60,6 +60,17 @@ func AssertResponseHeader(t *testing.T, got *http.Response, header string, want 
 	return true
 }
 
+func AssertResponseHeaderSet(t *testing.T, got *http.Response, header string) bool {
+	t.Helper()
+
+	_, ok := got.Header[header]
+	if !ok {
+		t.Errorf("header %q is not set", header)
+		return false
+	}
+	return true
+}
+
 func AssertResponseHeaderUnset(t *testing.T, got *http.Response, header string) bool {
 	t.Helper()
 

--- a/testing/conformance/content_management_test.go
+++ b/testing/conformance/content_management_test.go
@@ -21,7 +21,8 @@ func TestContentManagement(t *testing.T) {
 	defer ts.Close()
 
 	t.Run("Deleting tags", func(t *testing.T) {
-		repository, _, manifest := RandomManifest()
+		repository := RandomName()
+		_, manifest := RandomManifest()
 		tag := RandomVersion()
 
 		client := NewClient(t, ts.URL)
@@ -41,7 +42,8 @@ func TestContentManagement(t *testing.T) {
 	})
 
 	t.Run("Deleting manifests", func(t *testing.T) {
-		repository, digest, manifest := RandomManifest()
+		repository := RandomName()
+		digest, manifest := RandomManifest()
 
 		client := NewClient(t, ts.URL)
 
@@ -66,7 +68,8 @@ func TestContentManagement(t *testing.T) {
 	})
 
 	t.Run("Deleting blobs", func(t *testing.T) {
-		name, digest, content := RandomBlob(64)
+		name := RandomName()
+		digest, content := RandomBlob(64)
 
 		client := NewClient(t, ts.URL)
 

--- a/testing/conformance/pull_test.go
+++ b/testing/conformance/pull_test.go
@@ -25,7 +25,8 @@ func TestPull(t *testing.T) {
 		t.Run("GET request to a known manifest", func(t *testing.T) {
 			client := NewClient(t, ts.URL)
 
-			name, digest, manifest := RandomManifest()
+			name := RandomName()
+			digest, manifest := RandomManifest()
 			metadata.PutManifest(name, digest, digest.String())
 			blobs.Put(digest.String(), manifest.Bytes())
 
@@ -53,7 +54,9 @@ func TestPull(t *testing.T) {
 	})
 
 	t.Run("Pulling blobs", func(t *testing.T) {
-		name, digest, blob := RandomBlob(32)
+		name := RandomName()
+		digest, blob := RandomBlob(32)
+
 		metadata.PutBlob(name, digest, digest.String())
 		blobs.Put(digest.String(), blob)
 
@@ -81,7 +84,9 @@ func TestPull(t *testing.T) {
 		t.Run("HEAD request to an existing blob", func(t *testing.T) {
 			client := NewClient(t, ts.URL)
 
-			name, digest, blob := RandomBlob(32)
+			name := RandomName()
+			digest, blob := RandomBlob(32)
+
 			metadata.PutBlob(name, digest, digest.String())
 			blobs.Put(digest.String(), blob)
 
@@ -106,7 +111,9 @@ func TestPull(t *testing.T) {
 		t.Run("HEAD request to an existing manifest", func(t *testing.T) {
 			client := NewClient(t, ts.URL)
 
-			name, digest, manifest := RandomManifest()
+			name := RandomName()
+			digest, manifest := RandomManifest()
+
 			metadata.PutManifest(name, digest, digest.String())
 			blobs.Put(digest.String(), manifest.Bytes())
 

--- a/testing/conformance/push_test.go
+++ b/testing/conformance/push_test.go
@@ -28,7 +28,8 @@ func TestPush(t *testing.T) {
 			t.Run("POST then PUT", func(t *testing.T) {
 				client := NewClient(t, ts.URL)
 
-				name, digest, blob := RandomBlob(32)
+				name := RandomName()
+				digest, blob := RandomBlob(32)
 
 				// When obtaining a session ID, the response MUST have a code of 202 Accepted.
 				resp := client.InitUpload(name)
@@ -56,7 +57,8 @@ func TestPush(t *testing.T) {
 
 				// Registries MAY support pushing blobs using a single POST request.
 				// Cascade does not.
-				name, digest, blob := RandomBlob(32)
+				name := RandomName()
+				digest, blob := RandomBlob(32)
 				resp := client.UploadBlobSinglePOST(name, digest, blob)
 
 				// Registries that do not support single request monolithic uploads
@@ -70,7 +72,8 @@ func TestPush(t *testing.T) {
 		t.Run("Pushing a blob in chunks", func(t *testing.T) {
 			client := NewClient(t, ts.URL)
 
-			name, digest, blob := RandomBlob(64 * 1024)
+			name := RandomName()
+			digest, blob := RandomBlob(64 * 1024)
 
 			// Obtain a session ID
 			resp := client.InitUpload(name)
@@ -144,7 +147,8 @@ func TestPush(t *testing.T) {
 		t.Run("Pushing a blob as a stream", func(t *testing.T) {
 			client := NewClient(t, ts.URL)
 
-			name, digest, blob := RandomBlob(64 * 1024)
+			name := RandomName()
+			digest, blob := RandomBlob(64 * 1024)
 
 			resp := client.InitUpload(name)
 			AssertResponseCode(t, resp, http.StatusAccepted)
@@ -169,7 +173,8 @@ func TestPush(t *testing.T) {
 		t.Run("Pushing manifest by digest", func(t *testing.T) {
 			client := NewClient(t, ts.URL)
 
-			name, digest, manifest := RandomManifest()
+			name := RandomName()
+			digest, manifest := RandomManifest()
 
 			// Upon a successful upload, the registry MUST return response code 201 Created,
 			resp := client.PutManifest(name, digest.String(), manifest)
@@ -187,7 +192,8 @@ func TestPush(t *testing.T) {
 		t.Run("Pushing manifest by tag", func(t *testing.T) {
 			client := NewClient(t, ts.URL)
 
-			name, digest, manifest := RandomManifest()
+			name := RandomName()
+			digest, manifest := RandomManifest()
 			tag := "40"
 
 			// Upon a successful upload, the registry MUST return response code 201 Created,

--- a/testing/random.go
+++ b/testing/random.go
@@ -27,8 +27,7 @@ func RandomDigest() digest.Digest {
 	return digest.FromBytes(RandomContents(32))
 }
 
-func RandomManifest() (name string, id digest.Digest, manifest *cascade.Manifest) {
-	name = RandomName()
+func RandomManifest() (id digest.Digest, manifest *cascade.Manifest) {
 	content, _ := json.Marshal(v1.Manifest{
 		MediaType: v1.MediaTypeImageManifest,
 	})
@@ -37,8 +36,7 @@ func RandomManifest() (name string, id digest.Digest, manifest *cascade.Manifest
 	return
 }
 
-func RandomBlob(length int64) (name string, id digest.Digest, content []byte) {
-	name = RandomName()
+func RandomBlob(length int64) (id digest.Digest, content []byte) {
 	content = RandomContents(length)
 	id = digest.FromBytes(content)
 	return

--- a/testing/random.go
+++ b/testing/random.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand/v2"
+	"slices"
 	"strings"
 
 	"github.com/moby/moby/pkg/namesgenerator"
@@ -50,4 +51,14 @@ func RandomVersion() string {
 	patch = rand.IntN(60)
 
 	return fmt.Sprintf("v%d.%d.%d", major, minor, patch)
+}
+
+func RandomTags(count int) (tags []string) {
+	for range count {
+		tags = append(tags, RandomVersion())
+	}
+
+	slices.Sort(tags)
+
+	return
 }

--- a/uploads_test.go
+++ b/uploads_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/robinkb/cascade-registry"
+	. "github.com/robinkb/cascade-registry/testing"
 )
 
 func TestStatUpload(t *testing.T) {
@@ -13,14 +14,14 @@ func TestStatUpload(t *testing.T) {
 
 	t.Run("stat upload returns correct FileInfo", func(t *testing.T) {
 		repository := "a/v/c"
-		content := randomContents(32)
+		content := RandomContents(32)
 
 		session := service.InitUpload(repository)
 		err := service.AppendUpload(repository, session.ID.String(), bytes.NewBuffer(content), 0)
-		assertNoError(t, err)
+		RequireNoError(t, err)
 
 		info, err := service.StatUpload(repository, session.ID.String())
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		got := info.Size
 		want := len(content)
@@ -32,7 +33,7 @@ func TestStatUpload(t *testing.T) {
 
 	t.Run("stat upload on unknown upload returns ErrBlobUploadUnknown", func(t *testing.T) {
 		_, err := service.StatUpload("unknown/repo", "i-dont-exist")
-		assertErrorIs(t, err, cascade.ErrBlobUploadUnknown)
+		AssertErrorIs(t, err, cascade.ErrBlobUploadUnknown)
 	})
 
 	// TODO: Write test to ensure that uploads are scoped to a repository.
@@ -42,52 +43,55 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 	service, _, _ := newTestRegistry()
 
 	t.Run("Monolithic blob upload - happy path", func(t *testing.T) {
-		name, digest, content := randomBlob(32)
+		name := RandomName()
+		digest, content := RandomBlob(32)
 
 		session := service.InitUpload(name)
 
 		err := service.AppendUpload(name, session.ID.String(), bytes.NewBuffer(content), 0)
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		err = service.CloseUpload(name, session.ID.String(), digest.String())
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		r, err := service.GetBlob(name, digest.String())
-		assertNoError(t, err)
+		AssertNoError(t, err)
 		data, err := io.ReadAll(r)
-		assertNoError(t, err)
-		assertContent(t, data, content)
+		AssertNoError(t, err)
+		AssertSlicesEqual(t, data, content)
 	})
 
 	t.Run("Uploading without a session returns ErrBlobUploadUknown", func(t *testing.T) {
 		err := service.AppendUpload("fake", "abc", nil, 0)
-		assertErrorIs(t, err, cascade.ErrBlobUploadUnknown)
+		AssertErrorIs(t, err, cascade.ErrBlobUploadUnknown)
 	})
 
 	t.Run("Closing upload with invalid digest returns ErrDigestInvalid", func(t *testing.T) {
-		name, _, content := randomBlob(32)
+		name := RandomName()
+		content := RandomContents(32)
 		digest := "blablabla"
 
 		session := service.InitUpload(name)
 
 		err := service.AppendUpload(name, session.ID.String(), bytes.NewBuffer(content[0:16]), 0)
-		assertNoError(t, err)
+		RequireNoError(t, err)
 
 		err = service.CloseUpload(name, session.ID.String(), digest)
-		assertErrorIs(t, err, cascade.ErrDigestInvalid)
+		AssertErrorIs(t, err, cascade.ErrDigestInvalid)
 	})
 
 	t.Run("Closing upload with wrong digest returns ErrBlobUploadInvalid", func(t *testing.T) {
-		name, digest, _ := randomBlob(32)
-		otherContent := randomContents(32)
+		name := RandomName()
+		digest := RandomDigest()
+		otherContent := RandomContents(32)
 
 		session := service.InitUpload(name)
 
 		err := service.AppendUpload(name, session.ID.String(), bytes.NewBuffer(otherContent), 0)
-		assertNoError(t, err)
+		RequireNoError(t, err)
 
 		err = service.CloseUpload(name, session.ID.String(), digest.String())
-		assertErrorIs(t, err, cascade.ErrBlobUploadInvalid)
+		AssertErrorIs(t, err, cascade.ErrBlobUploadInvalid)
 	})
 }
 
@@ -95,41 +99,39 @@ func TestServiceUpload(t *testing.T) {
 	service, _, _ := newTestRegistry()
 
 	t.Run("written upload is retrievable", func(t *testing.T) {
-		name, digest, content := randomManifest()
+		name := RandomName()
+		digest, manifest := RandomManifest()
 
 		session := service.InitUpload(name)
 
-		err := service.AppendUpload(name, session.ID.String(), bytes.NewBuffer(content), 0)
-		assertNoError(t, err)
+		err := service.AppendUpload(name, session.ID.String(), bytes.NewBuffer(manifest.Bytes()), 0)
+		RequireNoError(t, err)
 
 		err = service.CloseUpload(name, session.ID.String(), digest.String())
-		assertNoError(t, err)
+		RequireNoError(t, err)
 
 		r, err := service.GetBlob(name, digest.String())
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		got, err := io.ReadAll(r)
-		assertNoError(t, err)
-
-		if !bytes.Equal(got, content) {
-			t.Errorf("got unexpected byte content; not equal to written content")
-		}
+		AssertNoError(t, err)
+		AssertSlicesEqual(t, got, manifest.Bytes())
 	})
 
 	t.Run("writing multiple times to same upload appends", func(t *testing.T) {
-		repository := "1/2/3"
-		content := randomContents(32)
+		repository := RandomName()
+		content := RandomContents(32)
 
 		session := service.InitUpload(repository)
 
 		err := service.AppendUpload(repository, session.ID.String(), bytes.NewBuffer(content[:16]), 0)
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		err = service.AppendUpload(repository, session.ID.String(), bytes.NewBuffer(content[16:]), 16)
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		info, err := service.StatUpload(repository, session.ID.String())
-		assertNoError(t, err)
+		AssertNoError(t, err)
 
 		got := info.Size
 		want := int64(len(content))
@@ -141,6 +143,6 @@ func TestServiceUpload(t *testing.T) {
 
 	t.Run("writing to unknown upload returns ErrBlobUploadUnknown", func(t *testing.T) {
 		err := service.AppendUpload("1/2/3", "i-dont-exist", nil, 0)
-		assertErrorIs(t, err, cascade.ErrBlobUploadUnknown)
+		AssertErrorIs(t, err, cascade.ErrBlobUploadUnknown)
 	})
 }


### PR DESCRIPTION
Replaces locally defined assertions and generator functions with equivalents from the testing package. 