### PR TITLE
Remove cascade.Manifest

### DIFF
--- a/manifests.go
+++ b/manifests.go
@@ -73,7 +73,8 @@ func (s *registryService) PutManifest(repository, reference string, content []by
 		return ErrDigestInvalid
 	}
 
-	err = json.Unmarshal(content, &v1.Manifest{})
+	var manifest v1.Manifest
+	err = json.Unmarshal(content, &manifest)
 	if err != nil {
 		return ErrManifestInvalid
 	}
@@ -85,7 +86,10 @@ func (s *registryService) PutManifest(repository, reference string, content []by
 		return err
 	}
 
-	return s.metadata.PutManifest(repository, digest, path)
+	return s.metadata.PutManifest(repository, digest, &ManifestMetadata{
+		Path:      path,
+		MediaType: manifest.MediaType,
+	})
 }
 
 func (s *registryService) DeleteManifest(repository, id string) error {

--- a/manifests.go
+++ b/manifests.go
@@ -9,26 +9,6 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func NewManifest(content []byte) (*Manifest, error) {
-	var manifest Manifest
-	err := json.Unmarshal(content, &manifest)
-	if err != nil {
-		err = ErrManifestInvalid
-	}
-	manifest.bytes = content
-
-	return &manifest, err
-}
-
-type Manifest struct {
-	v1.Manifest
-	bytes []byte
-}
-
-func (m *Manifest) Bytes() []byte {
-	return m.bytes
-}
-
 func (s *registryService) StatManifest(repository, id string) (*FileInfo, error) {
 	digest, err := digest.Parse(id)
 	if err != nil {

--- a/manifests.go
+++ b/manifests.go
@@ -35,12 +35,12 @@ func (s *registryService) StatManifest(repository, id string) (*FileInfo, error)
 		return nil, ErrManifestUnknown
 	}
 
-	path, err := s.metadata.GetManifest(repository, digest)
+	meta, err := s.metadata.GetManifest(repository, digest)
 	if err != nil {
 		return nil, ErrManifestUnknown
 	}
 
-	info, err := s.blobs.Stat(path)
+	info, err := s.blobs.Stat(meta.Path)
 	if errors.Is(err, ErrFileNotFound) {
 		return nil, ErrManifestUnknown
 	}
@@ -48,23 +48,23 @@ func (s *registryService) StatManifest(repository, id string) (*FileInfo, error)
 	return info, err
 }
 
-func (s *registryService) GetManifest(repository, id string) (*Manifest, error) {
+func (s *registryService) GetManifest(repository, id string) (*ManifestMetadata, []byte, error) {
 	digest, err := digest.Parse(id)
 	if err != nil {
-		return nil, ErrBlobUnknown
+		return nil, nil, ErrBlobUnknown
 	}
 
-	path, err := s.metadata.GetManifest(repository, digest)
+	meta, err := s.metadata.GetManifest(repository, digest)
 	if err != nil {
-		return nil, ErrManifestUnknown
+		return nil, nil, ErrManifestUnknown
 	}
 
-	content, err := s.blobs.Get(path)
+	content, err := s.blobs.Get(meta.Path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return NewManifest(content)
+	return meta, content, nil
 }
 
 func (s *registryService) PutManifest(repository, reference string, content []byte) error {
@@ -98,12 +98,12 @@ func (s *registryService) DeleteManifest(repository, id string) error {
 		return ErrManifestUnknown
 	}
 
-	path, err := s.metadata.GetManifest(repository, digest)
+	meta, err := s.metadata.GetManifest(repository, digest)
 	if err != nil {
 		return ErrManifestUnknown
 	}
 
-	err = s.blobs.Delete(path)
+	err = s.blobs.Delete(meta.Path)
 	if err != nil {
 		return err
 	}

--- a/manifests_test.go
+++ b/manifests_test.go
@@ -14,10 +14,10 @@ func TestStatManifest(t *testing.T) {
 	service, metadata, blobs := newTestRegistry()
 
 	name := RandomName()
-	digest, manifest := RandomManifest()
+	digest, _, content := RandomManifest()
 
 	path := digest.String()
-	blobs.Put(path, manifest.Bytes())
+	blobs.Put(path, content)
 	metadata.PutManifest(name, digest, &cascade.ManifestMetadata{
 		Path: path,
 	})
@@ -27,7 +27,7 @@ func TestStatManifest(t *testing.T) {
 		AssertNoError(t, err)
 
 		got := info.Size
-		want := int64(len(manifest.Bytes()))
+		want := int64(len(content))
 
 		if got != want {
 			t.Errorf("got size of %d, expected %d", got, want)
@@ -82,14 +82,14 @@ func TestPutManifest(t *testing.T) {
 
 	t.Run("Put and retrieve a manifest", func(t *testing.T) {
 		name := RandomName()
-		digest, manifest := RandomManifest()
+		digest, _, content := RandomManifest()
 
-		err := service.PutManifest(name, digest.String(), manifest.Bytes())
+		err := service.PutManifest(name, digest.String(), content)
 		AssertNoError(t, err)
 
 		_, got, err := service.GetManifest(name, digest.String())
 		AssertNoError(t, err)
-		AssertSlicesEqual(t, got, manifest.Bytes())
+		AssertSlicesEqual(t, got, content)
 	})
 
 	t.Run("Putting a manifest with invalid content returns ErrManifestInvalid", func(t *testing.T) {
@@ -106,9 +106,9 @@ func TestDeleteManifest(t *testing.T) {
 
 	t.Run("Delete manifest and make sure it cannot be retrieved", func(t *testing.T) {
 		name := RandomName()
-		digest, manifest := RandomManifest()
+		digest, _, content := RandomManifest()
 
-		err := service.PutManifest(name, digest.String(), manifest.Bytes())
+		err := service.PutManifest(name, digest.String(), content)
 		RequireNoError(t, err)
 
 		_, err = service.StatManifest(name, digest.String())

--- a/manifests_test.go
+++ b/manifests_test.go
@@ -66,13 +66,13 @@ func TestGetManifest(t *testing.T) {
 	})
 
 	t.Run("Retrieve an existing manifest", func(t *testing.T) {
-		got, err := service.GetManifest(name, digest.String())
+		_, got, err := service.GetManifest(name, digest.String())
 		AssertNoError(t, err)
-		AssertSlicesEqual(t, got.Bytes(), manifest)
+		AssertSlicesEqual(t, got, manifest)
 	})
 
 	t.Run("returns ErrManifestUnknown on unknown manifest", func(t *testing.T) {
-		_, err := service.GetManifest("i/do/not/exist", "sha256:ce5449ab65895b60068d164e81b646753d268583a70895acee51e1d711ddf3a2")
+		_, _, err := service.GetManifest("i/do/not/exist", "sha256:ce5449ab65895b60068d164e81b646753d268583a70895acee51e1d711ddf3a2")
 		AssertErrorIs(t, err, cascade.ErrManifestUnknown)
 	})
 }
@@ -87,9 +87,9 @@ func TestPutManifest(t *testing.T) {
 		err := service.PutManifest(name, digest.String(), manifest.Bytes())
 		AssertNoError(t, err)
 
-		got, err := service.GetManifest(name, digest.String())
+		_, got, err := service.GetManifest(name, digest.String())
 		AssertNoError(t, err)
-		AssertSlicesEqual(t, got.Bytes(), manifest.Bytes())
+		AssertSlicesEqual(t, got, manifest.Bytes())
 	})
 
 	t.Run("Putting a manifest with invalid content returns ErrManifestInvalid", func(t *testing.T) {

--- a/manifests_test.go
+++ b/manifests_test.go
@@ -18,7 +18,9 @@ func TestStatManifest(t *testing.T) {
 
 	path := digest.String()
 	blobs.Put(path, manifest.Bytes())
-	metadata.PutManifest(name, digest, path)
+	metadata.PutManifest(name, digest, &cascade.ManifestMetadata{
+		Path: path,
+	})
 
 	t.Run("Returns FileInfo with expected size on known manifest", func(t *testing.T) {
 		info, err := service.StatManifest(name, digest.String())
@@ -58,7 +60,10 @@ func TestGetManifest(t *testing.T) {
 
 	path := digest.String()
 	blobs.Put(path, manifest)
-	metadata.PutManifest(name, digest, path)
+	metadata.PutManifest(name, digest, &cascade.ManifestMetadata{
+		Path:      path,
+		MediaType: v1.MediaTypeImageLayer,
+	})
 
 	t.Run("Retrieve an existing manifest", func(t *testing.T) {
 		got, err := service.GetManifest(name, digest.String())

--- a/server/manifests.go
+++ b/server/manifests.go
@@ -62,15 +62,15 @@ func (s *Server) getManifestsHandler(w http.ResponseWriter, r *http.Request) {
 		reference, _ = s.service.GetTag(repository, reference)
 	}
 
-	manifest, err := s.service.GetManifest(repository, reference)
+	meta, content, err := s.service.GetManifest(repository, reference)
 	if err != nil {
 		writeErrorResponse(w, err)
 		return
 	}
 
-	w.Header().Set(HeaderContentType, manifest.MediaType)
+	w.Header().Set(HeaderContentType, meta.MediaType)
 	w.WriteHeader(http.StatusOK)
-	w.Write(manifest.Bytes())
+	w.Write(content)
 }
 
 func (s *Server) putManifestsHandler(w http.ResponseWriter, r *http.Request) {

--- a/server/manifests_test.go
+++ b/server/manifests_test.go
@@ -14,8 +14,8 @@ import (
 
 func TestStatManifests(t *testing.T) {
 	name := RandomName()
-	digest, manifest := RandomManifest()
-	length := len(manifest.Bytes())
+	digest, _, content := RandomManifest()
+	length := len(content)
 	tag := RandomVersion()
 
 	t.Run("Stat existing manifest returns 200 with correct size in Content-Length header", func(t *testing.T) {
@@ -29,7 +29,7 @@ func TestStatManifests(t *testing.T) {
 		resp := client.CheckManifestByDigest(name, digest)
 
 		AssertResponseCode(t, resp, http.StatusOK)
-		AssertResponseHeader(t, resp, server.HeaderContentLength, strconv.Itoa(len(manifest.Bytes())))
+		AssertResponseHeader(t, resp, server.HeaderContentLength, strconv.Itoa(len(content)))
 		AssertResponseBodyEquals(t, resp, nil)
 	})
 
@@ -47,7 +47,7 @@ func TestStatManifests(t *testing.T) {
 		resp := client.CheckManifestByTag(name, tag)
 
 		AssertResponseCode(t, resp, http.StatusOK)
-		AssertResponseHeader(t, resp, server.HeaderContentLength, strconv.Itoa(len(manifest.Bytes())))
+		AssertResponseHeader(t, resp, server.HeaderContentLength, strconv.Itoa(len(content)))
 		AssertResponseBodyEquals(t, resp, nil)
 	})
 
@@ -80,7 +80,7 @@ func TestStatManifests(t *testing.T) {
 
 func TestGetManifests(t *testing.T) {
 	name := RandomName()
-	digest, manifest := RandomManifest()
+	digest, manifest, content := RandomManifest()
 	meta := &cascade.ManifestMetadata{
 		MediaType: manifest.MediaType,
 		Path:      digest.String(),
@@ -91,7 +91,7 @@ func TestGetManifests(t *testing.T) {
 		service := mock.NewRegistryService(t)
 		service.EXPECT().
 			GetManifest(name, digest.String()).
-			Return(meta, manifest.Bytes(), nil)
+			Return(meta, content, nil)
 
 		client := NewTestClientWithServer(t, service)
 
@@ -99,7 +99,7 @@ func TestGetManifests(t *testing.T) {
 
 		AssertResponseCode(t, resp, http.StatusOK)
 		AssertResponseHeader(t, resp, server.HeaderContentType, v1.MediaTypeImageManifest)
-		AssertResponseBodyEquals(t, resp, manifest.Bytes())
+		AssertResponseBodyEquals(t, resp, content)
 	})
 
 	t.Run("Retrieving a manifest by tag returns 200", func(t *testing.T) {
@@ -109,14 +109,14 @@ func TestGetManifests(t *testing.T) {
 			Return(digest.String(), nil)
 		service.EXPECT().
 			GetManifest(name, digest.String()).
-			Return(meta, manifest.Bytes(), nil)
+			Return(meta, content, nil)
 
 		client := NewTestClientWithServer(t, service)
 
 		resp := client.GetManifestByTag(name, tag)
 
 		AssertResponseCode(t, resp, http.StatusOK)
-		AssertResponseBodyEquals(t, resp, manifest.Bytes())
+		AssertResponseBodyEquals(t, resp, content)
 	})
 
 	t.Run("Retrieving a non-existent manifest returns status 404 and ErrManifestUnknown", func(t *testing.T) {
@@ -136,18 +136,18 @@ func TestGetManifests(t *testing.T) {
 
 func TestPutManifest(t *testing.T) {
 	name := RandomName()
-	digest, manifest := RandomManifest()
+	digest, _, content := RandomManifest()
 	tag := RandomVersion()
 
 	t.Run("Uploading a manifest by digest returns code 201", func(t *testing.T) {
 		service := mock.NewRegistryService(t)
 		service.EXPECT().
-			PutManifest(name, digest.String(), manifest.Bytes()).
+			PutManifest(name, digest.String(), content).
 			Return(nil)
 
 		client := NewTestClientWithServer(t, service)
 
-		resp := client.PutManifest(name, digest.String(), manifest)
+		resp := client.PutManifest(name, digest.String(), content)
 
 		AssertResponseCode(t, resp, http.StatusCreated)
 		AssertResponseHeaderSet(t, resp, server.HeaderLocation)
@@ -160,12 +160,12 @@ func TestPutManifest(t *testing.T) {
 			PutTag(name, tag, digest.String()).
 			Return(nil)
 		service.EXPECT().
-			PutManifest(name, digest.String(), manifest.Bytes()).
+			PutManifest(name, digest.String(), content).
 			Return(nil)
 
 		client := NewTestClientWithServer(t, service)
 
-		resp := client.PutManifest(name, tag, manifest)
+		resp := client.PutManifest(name, tag, content)
 
 		AssertResponseCode(t, resp, http.StatusCreated)
 		AssertResponseHeaderSet(t, resp, server.HeaderLocation)
@@ -175,12 +175,12 @@ func TestPutManifest(t *testing.T) {
 	t.Run("Uploading an invalid manifest returns 400 and ErrManifestInvalid", func(t *testing.T) {
 		service := mock.NewRegistryService(t)
 		service.EXPECT().
-			PutManifest(name, digest.String(), manifest.Bytes()).
+			PutManifest(name, digest.String(), content).
 			Return(cascade.ErrManifestInvalid)
 
 		client := NewTestClientWithServer(t, service)
 
-		resp := client.PutManifest(name, tag, manifest)
+		resp := client.PutManifest(name, tag, content)
 
 		AssertResponseCode(t, resp, http.StatusBadRequest)
 		AssertResponseBodyContainsError(t, resp, cascade.ErrManifestInvalid)

--- a/server/manifests_test.go
+++ b/server/manifests_test.go
@@ -81,13 +81,17 @@ func TestStatManifests(t *testing.T) {
 func TestGetManifests(t *testing.T) {
 	name := RandomName()
 	digest, manifest := RandomManifest()
+	meta := &cascade.ManifestMetadata{
+		MediaType: manifest.MediaType,
+		Path:      digest.String(),
+	}
 	tag := RandomVersion()
 
 	t.Run("Retrieving an existing manifest returns 200", func(t *testing.T) {
 		service := mock.NewRegistryService(t)
 		service.EXPECT().
 			GetManifest(name, digest.String()).
-			Return(cascade.NewManifest(manifest.Bytes()))
+			Return(meta, manifest.Bytes(), nil)
 
 		client := NewTestClientWithServer(t, service)
 
@@ -105,7 +109,7 @@ func TestGetManifests(t *testing.T) {
 			Return(digest.String(), nil)
 		service.EXPECT().
 			GetManifest(name, digest.String()).
-			Return(cascade.NewManifest(manifest.Bytes()))
+			Return(meta, manifest.Bytes(), nil)
 
 		client := NewTestClientWithServer(t, service)
 
@@ -119,7 +123,7 @@ func TestGetManifests(t *testing.T) {
 		service := mock.NewRegistryService(t)
 		service.EXPECT().
 			GetManifest(name, digest.String()).
-			Return(nil, cascade.ErrManifestUnknown)
+			Return(nil, nil, cascade.ErrManifestUnknown)
 
 		client := NewTestClientWithServer(t, service)
 

--- a/service.go
+++ b/service.go
@@ -14,7 +14,7 @@ type (
 		DeleteBlob(repository, digest string) error
 
 		StatManifest(repository, reference string) (*FileInfo, error)
-		GetManifest(repository, reference string) (*Manifest, error)
+		GetManifest(repository, reference string) (*ManifestMetadata, []byte, error)
 		PutManifest(repository, reference string, content []byte) error
 		DeleteManifest(repository, reference string) error
 

--- a/store.go
+++ b/store.go
@@ -22,7 +22,7 @@ type (
 		DeleteBlob(repository string, digest digest.Digest) error
 
 		GetManifest(repository string, digest digest.Digest) (string, error)
-		PutManifest(repository string, digest digest.Digest, path string) error
+		PutManifest(repository string, digest digest.Digest, meta *ManifestMetadata) error
 		DeleteManifest(repository string, digest digest.Digest) error
 
 		ListTags(repository string, count int, last string) ([]string, error)
@@ -64,5 +64,11 @@ type (
 	FileInfo struct {
 		Name string
 		Size int64
+	}
+
+	// ManifestMetadata represents the metadata of a manifest that is stored in the MetadataStore.
+	ManifestMetadata struct {
+		Path      string
+		MediaType string
 	}
 )

--- a/store.go
+++ b/store.go
@@ -21,7 +21,7 @@ type (
 		PutBlob(repository string, digest digest.Digest, path string) error
 		DeleteBlob(repository string, digest digest.Digest) error
 
-		GetManifest(repository string, digest digest.Digest) (string, error)
+		GetManifest(repository string, digest digest.Digest) (*ManifestMetadata, error)
 		PutManifest(repository string, digest digest.Digest, meta *ManifestMetadata) error
 		DeleteManifest(repository string, digest digest.Digest) error
 

--- a/store/inmemory/metadata.go
+++ b/store/inmemory/metadata.go
@@ -75,13 +75,16 @@ func (s *MetadataStore) DeleteBlob(repository string, digest digest.Digest) erro
 	return nil
 }
 
-func (s *MetadataStore) GetManifest(repository string, digest digest.Digest) (string, error) {
+func (s *MetadataStore) GetManifest(repository string, digest digest.Digest) (*cascade.ManifestMetadata, error) {
 	if repo, ok := s.repositories[repository]; ok {
 		if manifest, ok := repo.manifests[digest.String()]; ok {
-			return manifest.path, nil
+			return &cascade.ManifestMetadata{
+				Path:      manifest.path,
+				MediaType: manifest.mediaType,
+			}, nil
 		}
 	}
-	return "", cascade.ErrManifestUnknown
+	return nil, cascade.ErrManifestUnknown
 }
 
 func (s *MetadataStore) PutManifest(repository string, digest digest.Digest, meta *cascade.ManifestMetadata) error {

--- a/store/inmemory/metadata.go
+++ b/store/inmemory/metadata.go
@@ -28,7 +28,8 @@ type (
 	}
 
 	Manifest struct {
-		path string
+		path      string
+		mediaType string
 	}
 
 	Blob struct {
@@ -83,10 +84,11 @@ func (s *MetadataStore) GetManifest(repository string, digest digest.Digest) (st
 	return "", cascade.ErrManifestUnknown
 }
 
-func (s *MetadataStore) PutManifest(repository string, digest digest.Digest, path string) error {
+func (s *MetadataStore) PutManifest(repository string, digest digest.Digest, meta *cascade.ManifestMetadata) error {
 	s.ensureRepositoryExists(repository)
 	s.repositories[repository].manifests[digest.String()] = &Manifest{
-		path: path,
+		path:      meta.Path,
+		mediaType: meta.MediaType,
 	}
 	return nil
 }

--- a/tags_test.go
+++ b/tags_test.go
@@ -49,10 +49,10 @@ func TestPutTag(t *testing.T) {
 		gotDigest, err := service.GetTag(name, tag)
 		AssertNoError(t, err)
 
-		gotManifest, err := service.GetManifest(name, gotDigest)
+		_, gotManifest, err := service.GetManifest(name, gotDigest)
 		AssertNoError(t, err)
 
-		AssertSlicesEqual(t, gotManifest.Bytes(), manifest.Bytes())
+		AssertSlicesEqual(t, gotManifest, manifest.Bytes())
 	})
 }
 

--- a/tags_test.go
+++ b/tags_test.go
@@ -37,10 +37,10 @@ func TestPutTag(t *testing.T) {
 
 	t.Run("Tag creates a link to the manifest digest", func(t *testing.T) {
 		name := RandomName()
-		digest, manifest := RandomManifest()
+		digest, _, content := RandomManifest()
 		tag := "v0.5.1"
 
-		err := service.PutManifest(name, digest.String(), manifest.Bytes())
+		err := service.PutManifest(name, digest.String(), content)
 		AssertNoError(t, err)
 
 		err = service.PutTag(name, tag, digest.String())
@@ -52,7 +52,7 @@ func TestPutTag(t *testing.T) {
 		_, gotManifest, err := service.GetManifest(name, gotDigest)
 		AssertNoError(t, err)
 
-		AssertSlicesEqual(t, gotManifest, manifest.Bytes())
+		AssertSlicesEqual(t, gotManifest, content)
 	})
 }
 

--- a/testing/client.go
+++ b/testing/client.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/go-digest"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/robinkb/cascade-registry"
 	"github.com/robinkb/cascade-registry/server"
 )
@@ -83,12 +85,19 @@ func (c *Client) GetManifestByTag(name string, tag string) *http.Response {
 	return c.Do(http.MethodGet, path, nil, nil)
 }
 
-func (c *Client) PutManifest(name string, reference string, manifest *cascade.Manifest) *http.Response {
+func (c *Client) PutManifest(name string, reference string, content []byte) *http.Response {
 	path := fmt.Sprintf("/v2/%s/manifests/%s", name, reference)
+
+	var manifest v1.Manifest
+	err := json.Unmarshal(content, &manifest)
+	if err != nil {
+		c.t.Fatal("failed to unmarshal manifest")
+	}
+
 	headers := make(http.Header)
 	headers.Set("Content-Type", manifest.MediaType)
 
-	return c.Do(http.MethodPut, path, headers, bytes.NewBuffer(manifest.Bytes()))
+	return c.Do(http.MethodPut, path, headers, bytes.NewBuffer(content))
 }
 
 func (c *Client) DeleteManifest(name string, digest digest.Digest) *http.Response {

--- a/testing/conformance/content_management_test.go
+++ b/testing/conformance/content_management_test.go
@@ -22,7 +22,7 @@ func TestContentManagement(t *testing.T) {
 
 	t.Run("Deleting tags", func(t *testing.T) {
 		repository := RandomName()
-		_, manifest := RandomManifest()
+		_, _, manifest := RandomManifest()
 		tag := RandomVersion()
 
 		client := NewTestClient(t, ts.URL)
@@ -43,11 +43,11 @@ func TestContentManagement(t *testing.T) {
 
 	t.Run("Deleting manifests", func(t *testing.T) {
 		repository := RandomName()
-		digest, manifest := RandomManifest()
+		digest, _, content := RandomManifest()
 
 		client := NewTestClient(t, ts.URL)
 
-		resp := client.PutManifest(repository, digest.String(), manifest)
+		resp := client.PutManifest(repository, digest.String(), content)
 		AssertResponseCode(t, resp, http.StatusCreated)
 
 		resp = client.CheckManifestByDigest(repository, digest)

--- a/testing/conformance/pull_test.go
+++ b/testing/conformance/pull_test.go
@@ -26,18 +26,18 @@ func TestPull(t *testing.T) {
 			client := NewTestClient(t, ts.URL)
 
 			name := RandomName()
-			digest, manifest := RandomManifest()
+			digest, manifest, content := RandomManifest()
 			metadata.PutManifest(name, digest, &cascade.ManifestMetadata{
 				Path:      digest.String(),
 				MediaType: manifest.MediaType,
 			})
-			blobs.Put(digest.String(), manifest.Bytes())
+			blobs.Put(digest.String(), content)
 
 			resp := client.GetManifestByDigest(name, digest)
 
 			// A GET request to an existing manifest URL MUST provide the expected manifest, with a response code that MUST be 200 OK.
 			AssertResponseCode(t, resp, http.StatusOK)
-			AssertResponseBodyEquals(t, resp, manifest.Bytes())
+			AssertResponseBodyEquals(t, resp, content)
 
 			// In a successful response, the Content-Type header will indicate the type of the returned manifest.
 			// The registry SHOULD NOT include parameters on the Content-Type header.
@@ -115,12 +115,12 @@ func TestPull(t *testing.T) {
 			client := NewTestClient(t, ts.URL)
 
 			name := RandomName()
-			digest, manifest := RandomManifest()
+			digest, _, content := RandomManifest()
 
 			metadata.PutManifest(name, digest, &cascade.ManifestMetadata{
 				Path: digest.String(),
 			})
-			blobs.Put(digest.String(), manifest.Bytes())
+			blobs.Put(digest.String(), content)
 
 			resp := client.CheckManifestByDigest(name, digest)
 
@@ -128,7 +128,7 @@ func TestPull(t *testing.T) {
 			AssertResponseCode(t, resp, http.StatusOK)
 
 			// A successful response SHOULD contain the size in bytes of the uploaded blob in the header Content-Length.
-			contentLength := strconv.Itoa(len(manifest.Bytes()))
+			contentLength := strconv.Itoa(len(content))
 			AssertResponseHeader(t, resp, "Content-Length", contentLength)
 		})
 

--- a/testing/conformance/pull_test.go
+++ b/testing/conformance/pull_test.go
@@ -28,7 +28,8 @@ func TestPull(t *testing.T) {
 			name := RandomName()
 			digest, manifest := RandomManifest()
 			metadata.PutManifest(name, digest, &cascade.ManifestMetadata{
-				Path: digest.String(),
+				Path:      digest.String(),
+				MediaType: manifest.MediaType,
 			})
 			blobs.Put(digest.String(), manifest.Bytes())
 

--- a/testing/conformance/pull_test.go
+++ b/testing/conformance/pull_test.go
@@ -27,7 +27,9 @@ func TestPull(t *testing.T) {
 
 			name := RandomName()
 			digest, manifest := RandomManifest()
-			metadata.PutManifest(name, digest, digest.String())
+			metadata.PutManifest(name, digest, &cascade.ManifestMetadata{
+				Path: digest.String(),
+			})
 			blobs.Put(digest.String(), manifest.Bytes())
 
 			resp := client.GetManifestByDigest(name, digest)
@@ -114,7 +116,9 @@ func TestPull(t *testing.T) {
 			name := RandomName()
 			digest, manifest := RandomManifest()
 
-			metadata.PutManifest(name, digest, digest.String())
+			metadata.PutManifest(name, digest, &cascade.ManifestMetadata{
+				Path: digest.String(),
+			})
 			blobs.Put(digest.String(), manifest.Bytes())
 
 			resp := client.CheckManifestByDigest(name, digest)

--- a/testing/conformance/push_test.go
+++ b/testing/conformance/push_test.go
@@ -174,10 +174,10 @@ func TestPush(t *testing.T) {
 			client := NewTestClient(t, ts.URL)
 
 			name := RandomName()
-			digest, manifest := RandomManifest()
+			digest, _, content := RandomManifest()
 
 			// Upon a successful upload, the registry MUST return response code 201 Created,
-			resp := client.PutManifest(name, digest.String(), manifest)
+			resp := client.PutManifest(name, digest.String(), content)
 			AssertResponseCode(t, resp, http.StatusCreated)
 			// and MUST have the following header:
 			location, err := resp.Location()
@@ -186,18 +186,18 @@ func TestPush(t *testing.T) {
 			resp = client.Do(http.MethodGet, location.RequestURI(), nil, nil)
 			AssertResponseCode(t, resp, http.StatusOK)
 			// The registry MUST store the manifest in the exact byte representation provided by the client.
-			AssertResponseBodyEquals(t, resp, manifest.Bytes())
+			AssertResponseBodyEquals(t, resp, content)
 		})
 
 		t.Run("Pushing manifest by tag", func(t *testing.T) {
 			client := NewTestClient(t, ts.URL)
 
 			name := RandomName()
-			digest, manifest := RandomManifest()
+			digest, _, content := RandomManifest()
 			tag := "40"
 
 			// Upon a successful upload, the registry MUST return response code 201 Created,
-			resp := client.PutManifest(name, tag, manifest)
+			resp := client.PutManifest(name, tag, content)
 			AssertResponseCode(t, resp, http.StatusCreated)
 			// and MUST have the following header:
 			location, err := resp.Location()
@@ -206,11 +206,11 @@ func TestPush(t *testing.T) {
 			resp = client.Do(http.MethodGet, location.RequestURI(), nil, nil)
 			AssertResponseCode(t, resp, http.StatusOK)
 			// The registry MUST store the manifest in the exact byte representation provided by the client.
-			AssertResponseBodyEquals(t, resp, manifest.Bytes())
+			AssertResponseBodyEquals(t, resp, content)
 
 			resp = client.GetManifestByDigest(name, digest)
 			AssertResponseCode(t, resp, http.StatusOK)
-			AssertResponseBodyEquals(t, resp, manifest.Bytes())
+			AssertResponseBodyEquals(t, resp, content)
 		})
 
 		t.Run("Pushing manifest with layers", func(t *testing.T) {})

--- a/testing/mock/registry_service.go
+++ b/testing/mock/registry_service.go
@@ -321,33 +321,42 @@ func (_c *RegistryService_GetBlob_Call) RunAndReturn(run func(string, string) (i
 }
 
 // GetManifest provides a mock function with given fields: repository, reference
-func (_m *RegistryService) GetManifest(repository string, reference string) (*cascade.Manifest, error) {
+func (_m *RegistryService) GetManifest(repository string, reference string) (*cascade.ManifestMetadata, []byte, error) {
 	ret := _m.Called(repository, reference)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetManifest")
 	}
 
-	var r0 *cascade.Manifest
-	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string) (*cascade.Manifest, error)); ok {
+	var r0 *cascade.ManifestMetadata
+	var r1 []byte
+	var r2 error
+	if rf, ok := ret.Get(0).(func(string, string) (*cascade.ManifestMetadata, []byte, error)); ok {
 		return rf(repository, reference)
 	}
-	if rf, ok := ret.Get(0).(func(string, string) *cascade.Manifest); ok {
+	if rf, ok := ret.Get(0).(func(string, string) *cascade.ManifestMetadata); ok {
 		r0 = rf(repository, reference)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*cascade.Manifest)
+			r0 = ret.Get(0).(*cascade.ManifestMetadata)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+	if rf, ok := ret.Get(1).(func(string, string) []byte); ok {
 		r1 = rf(repository, reference)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]byte)
+		}
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(string, string) error); ok {
+		r2 = rf(repository, reference)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // RegistryService_GetManifest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetManifest'
@@ -369,12 +378,12 @@ func (_c *RegistryService_GetManifest_Call) Run(run func(repository string, refe
 	return _c
 }
 
-func (_c *RegistryService_GetManifest_Call) Return(_a0 *cascade.Manifest, _a1 error) *RegistryService_GetManifest_Call {
-	_c.Call.Return(_a0, _a1)
+func (_c *RegistryService_GetManifest_Call) Return(_a0 *cascade.ManifestMetadata, _a1 []byte, _a2 error) *RegistryService_GetManifest_Call {
+	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *RegistryService_GetManifest_Call) RunAndReturn(run func(string, string) (*cascade.Manifest, error)) *RegistryService_GetManifest_Call {
+func (_c *RegistryService_GetManifest_Call) RunAndReturn(run func(string, string) (*cascade.ManifestMetadata, []byte, error)) *RegistryService_GetManifest_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/testing/random.go
+++ b/testing/random.go
@@ -11,7 +11,6 @@ import (
 	"github.com/moby/moby/pkg/namesgenerator"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/robinkb/cascade-registry"
 )
 
 func RandomName() string {
@@ -28,12 +27,12 @@ func RandomDigest() digest.Digest {
 	return digest.FromBytes(RandomContents(32))
 }
 
-func RandomManifest() (id digest.Digest, manifest *cascade.Manifest) {
-	content, _ := json.Marshal(v1.Manifest{
+func RandomManifest() (id digest.Digest, manifest *v1.Manifest, content []byte) {
+	manifest = &v1.Manifest{
 		MediaType: v1.MediaTypeImageManifest,
-	})
+	}
+	content, _ = json.Marshal(manifest)
 	id = digest.FromBytes(content)
-	manifest, _ = cascade.NewManifest(content)
 	return
 }
 

--- a/uploads_test.go
+++ b/uploads_test.go
@@ -100,11 +100,11 @@ func TestServiceUpload(t *testing.T) {
 
 	t.Run("written upload is retrievable", func(t *testing.T) {
 		name := RandomName()
-		digest, manifest := RandomManifest()
+		digest, _, content := RandomManifest()
 
 		session := service.InitUpload(name)
 
-		err := service.AppendUpload(name, session.ID.String(), bytes.NewBuffer(manifest.Bytes()), 0)
+		err := service.AppendUpload(name, session.ID.String(), bytes.NewBuffer(content), 0)
 		RequireNoError(t, err)
 
 		err = service.CloseUpload(name, session.ID.String(), digest.String())
@@ -115,7 +115,7 @@ func TestServiceUpload(t *testing.T) {
 
 		got, err := io.ReadAll(r)
 		AssertNoError(t, err)
-		AssertSlicesEqual(t, got, manifest.Bytes())
+		AssertSlicesEqual(t, got, content)
 	})
 
 	t.Run("writing multiple times to same upload appends", func(t *testing.T) {


### PR DESCRIPTION
Removes the cascade.Manifest type.

The cascade.Manifest type was kinda problematic, because it embedded the original image-spec Manifest and added the original byte contents. That _probably_ increased the memory footprint, and was _definitely_ a quick and dirty solution to another problem: Storing and retrieving certain metadata about the manifests.

While removing the cascade.Manifest type, this PR starts to store more information about manifests in the MetadataStore. This removes the need to parse manifests when they are retrieved by the client, instead fetching the required metadata like the media type from the MetadataStore.

This is also a nice setup for the work on Referrers API. The list of descriptors returned by the Referrers API can be constructed completely from the MetadataStore instead of having to fetch and parse every referring manifest.