### PR TITLE
Referrers API - Return metadata

### DIFF
--- a/manifests.go
+++ b/manifests.go
@@ -72,14 +72,20 @@ func (s *registryService) PutManifest(repository, reference string, content []by
 		return "", err
 	}
 
-	err = s.metadata.PutManifest(repository, digest, &ManifestMetadata{
+	meta := &ManifestMetadata{
 		Annotations:  manifest.Annotations,
 		ArtifactType: manifest.ArtifactType,
 		MediaType:    manifest.MediaType,
 		Path:         path,
 		Subject:      subject,
 		Size:         int64(len(content)),
-	})
+	}
+
+	if meta.ArtifactType == "" && manifest.MediaType == v1.MediaTypeImageManifest {
+		meta.ArtifactType = manifest.Config.MediaType
+	}
+
+	err = s.metadata.PutManifest(repository, digest, meta)
 
 	return subject, err
 }

--- a/manifests.go
+++ b/manifests.go
@@ -73,11 +73,12 @@ func (s *registryService) PutManifest(repository, reference string, content []by
 	}
 
 	err = s.metadata.PutManifest(repository, digest, &ManifestMetadata{
-		Annotations: manifest.Annotations,
-		MediaType:   manifest.MediaType,
-		Path:        path,
-		Subject:     subject,
-		Size:        int64(len(content)),
+		Annotations:  manifest.Annotations,
+		ArtifactType: manifest.ArtifactType,
+		MediaType:    manifest.MediaType,
+		Path:         path,
+		Subject:      subject,
+		Size:         int64(len(content)),
 	})
 
 	return subject, err

--- a/manifests.go
+++ b/manifests.go
@@ -73,9 +73,11 @@ func (s *registryService) PutManifest(repository, reference string, content []by
 	}
 
 	err = s.metadata.PutManifest(repository, digest, &ManifestMetadata{
-		Path:      path,
-		MediaType: manifest.MediaType,
-		Subject:   subject,
+		Annotations: manifest.Annotations,
+		MediaType:   manifest.MediaType,
+		Path:        path,
+		Subject:     subject,
+		Size:        int64(len(content)),
 	})
 
 	return subject, err

--- a/referrers.go
+++ b/referrers.go
@@ -16,7 +16,20 @@ func (s *registryService) ListReferrers(name, reference string) (*v1.Index, erro
 		return nil, err
 	}
 
-	return &v1.Index{
-		Manifests: referrers,
-	}, nil
+	idx := v1.Index{
+		Manifests: make([]v1.Descriptor, 0),
+	}
+
+	for _, referrer := range referrers {
+		// meta, err := s.metadata.GetManifest(name, referrer)
+		// if err != nil {
+		// 	return nil, err
+		// }
+
+		idx.Manifests = append(idx.Manifests, v1.Descriptor{
+			Digest: referrer,
+		})
+	}
+
+	return &idx, nil
 }

--- a/referrers.go
+++ b/referrers.go
@@ -27,9 +27,10 @@ func (s *registryService) ListReferrers(name, reference string) (*v1.Index, erro
 		}
 
 		idx.Manifests = append(idx.Manifests, v1.Descriptor{
-			Annotations: meta.Annotations,
-			Digest:      referrer,
-			Size:        meta.Size,
+			Annotations:  meta.Annotations,
+			ArtifactType: meta.ArtifactType,
+			Digest:       referrer,
+			Size:         meta.Size,
 		})
 	}
 

--- a/referrers.go
+++ b/referrers.go
@@ -30,6 +30,7 @@ func (s *registryService) ListReferrers(name, reference string) (*v1.Index, erro
 			Annotations:  meta.Annotations,
 			ArtifactType: meta.ArtifactType,
 			Digest:       referrer,
+			MediaType:    meta.MediaType,
 			Size:         meta.Size,
 		})
 	}

--- a/referrers.go
+++ b/referrers.go
@@ -21,13 +21,15 @@ func (s *registryService) ListReferrers(name, reference string) (*v1.Index, erro
 	}
 
 	for _, referrer := range referrers {
-		// meta, err := s.metadata.GetManifest(name, referrer)
-		// if err != nil {
-		// 	return nil, err
-		// }
+		meta, err := s.metadata.GetManifest(name, referrer)
+		if err != nil {
+			return nil, err
+		}
 
 		idx.Manifests = append(idx.Manifests, v1.Descriptor{
-			Digest: referrer,
+			Annotations: meta.Annotations,
+			Digest:      referrer,
+			Size:        meta.Size,
 		})
 	}
 

--- a/store.go
+++ b/store.go
@@ -67,8 +67,10 @@ type (
 
 	// ManifestMetadata represents the metadata of a manifest that is stored in the MetadataStore.
 	ManifestMetadata struct {
-		Path      string
-		MediaType string
-		Subject   digest.Digest
+		Annotations map[string]string
+		MediaType   string
+		Path        string
+		Subject     digest.Digest
+		Size        int64
 	}
 )

--- a/store.go
+++ b/store.go
@@ -5,7 +5,6 @@ import (
 	"io"
 
 	"github.com/opencontainers/go-digest"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 var (
@@ -31,7 +30,7 @@ type (
 		PutTag(repository, tag string, digest digest.Digest) error
 		DeleteTag(repository, tag string) error
 
-		ListReferrers(repository string, digest digest.Digest) ([]v1.Descriptor, error)
+		ListReferrers(repository string, digest digest.Digest) ([]digest.Digest, error)
 
 		GetUploadSession(repository string, id string) (*UploadSession, error)
 		PutUploadSession(repository string, session *UploadSession) error

--- a/store.go
+++ b/store.go
@@ -67,10 +67,11 @@ type (
 
 	// ManifestMetadata represents the metadata of a manifest that is stored in the MetadataStore.
 	ManifestMetadata struct {
-		Annotations map[string]string
-		MediaType   string
-		Path        string
-		Subject     digest.Digest
-		Size        int64
+		Annotations  map[string]string
+		ArtifactType string
+		MediaType    string
+		Path         string
+		Subject      digest.Digest
+		Size         int64
 	}
 )

--- a/store/inmemory/metadata.go
+++ b/store/inmemory/metadata.go
@@ -4,7 +4,6 @@ import (
 	"slices"
 
 	godigest "github.com/opencontainers/go-digest"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/robinkb/cascade-registry"
 )
 
@@ -180,9 +179,7 @@ func (s *metadataStore) DeleteTag(repository, tag string) error {
 	return nil
 }
 
-func (s *metadataStore) ListReferrers(repository string, digest godigest.Digest) ([]v1.Descriptor, error) {
-	descriptors := make([]v1.Descriptor, 0)
-
+func (s *metadataStore) ListReferrers(repository string, digest godigest.Digest) ([]godigest.Digest, error) {
 	repo, ok := s.repositories[repository]
 	if !ok {
 		return nil, cascade.ErrNameUnknown
@@ -190,21 +187,16 @@ func (s *metadataStore) ListReferrers(repository string, digest godigest.Digest)
 
 	manifest, ok := repo.manifests[digest.String()]
 	if !ok {
-		return []v1.Descriptor{}, nil
+		return []godigest.Digest{}, nil
 	}
+
+	referrers := make([]godigest.Digest, 0)
 
 	for d := range manifest.referrers {
-		_, err := s.GetManifest(repository, d)
-		if err != nil {
-			return nil, err
-		}
-
-		descriptors = append(descriptors, v1.Descriptor{
-			Digest: d,
-		})
+		referrers = append(referrers, d)
 	}
 
-	return descriptors, nil
+	return referrers, nil
 }
 
 func (s *metadataStore) GetUploadSession(repository, id string) (*cascade.UploadSession, error) {

--- a/store/inmemory/metadata.go
+++ b/store/inmemory/metadata.go
@@ -28,11 +28,12 @@ type (
 	}
 
 	manifest struct {
-		annotations map[string]string
-		mediaType   string
-		path        string
-		referrers   map[godigest.Digest]any
-		size        int64
+		annotations  map[string]string
+		artifactType string
+		mediaType    string
+		path         string
+		referrers    map[godigest.Digest]any
+		size         int64
 	}
 
 	blob struct {
@@ -84,10 +85,11 @@ func (s *metadataStore) GetManifest(repository string, digest godigest.Digest) (
 	if repo, ok := s.repositories[repository]; ok {
 		if manifest, ok := repo.manifests[digest.String()]; ok {
 			return &cascade.ManifestMetadata{
-				Annotations: manifest.annotations,
-				MediaType:   manifest.mediaType,
-				Path:        manifest.path,
-				Size:        manifest.size,
+				Annotations:  manifest.annotations,
+				ArtifactType: manifest.artifactType,
+				MediaType:    manifest.mediaType,
+				Path:         manifest.path,
+				Size:         manifest.size,
 			}, nil
 		}
 	}
@@ -105,6 +107,7 @@ func (s *metadataStore) PutManifest(repository string, digest godigest.Digest, m
 	}
 
 	manifests.annotations = meta.Annotations
+	manifests.artifactType = meta.ArtifactType
 	manifests.mediaType = meta.MediaType
 	manifests.path = meta.Path
 	manifests.size = meta.Size

--- a/store/inmemory/metadata.go
+++ b/store/inmemory/metadata.go
@@ -28,9 +28,11 @@ type (
 	}
 
 	manifest struct {
-		path      string
-		mediaType string
-		referrers map[godigest.Digest]any
+		annotations map[string]string
+		mediaType   string
+		path        string
+		referrers   map[godigest.Digest]any
+		size        int64
 	}
 
 	blob struct {
@@ -82,8 +84,10 @@ func (s *metadataStore) GetManifest(repository string, digest godigest.Digest) (
 	if repo, ok := s.repositories[repository]; ok {
 		if manifest, ok := repo.manifests[digest.String()]; ok {
 			return &cascade.ManifestMetadata{
-				Path:      manifest.path,
-				MediaType: manifest.mediaType,
+				Annotations: manifest.annotations,
+				MediaType:   manifest.mediaType,
+				Path:        manifest.path,
+				Size:        manifest.size,
 			}, nil
 		}
 	}
@@ -100,8 +104,10 @@ func (s *metadataStore) PutManifest(repository string, digest godigest.Digest, m
 		s.repositories[repository].manifests[digest.String()] = manifests
 	}
 
-	manifests.path = meta.Path
+	manifests.annotations = meta.Annotations
 	manifests.mediaType = meta.MediaType
+	manifests.path = meta.Path
+	manifests.size = meta.Size
 
 	if meta.Subject != "" {
 		manifests, ok := s.repositories[repository].manifests[meta.Subject.String()]

--- a/store/inmemory/metadata_test.go
+++ b/store/inmemory/metadata_test.go
@@ -1,0 +1,34 @@
+// Tests in this file should be moved into the store package,
+// so that they can be easily run against every metadata store implementation.
+package inmemory
+
+import (
+	"testing"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/robinkb/cascade-registry"
+	. "github.com/robinkb/cascade-registry/testing"
+)
+
+func TestManifestMetadataPersistence(t *testing.T) {
+	metadata := NewMetadataStore()
+
+	name := RandomName()
+	digest := RandomDigest()
+
+	wantMetadata := &cascade.ManifestMetadata{
+		Annotations: map[string]string{
+			"random": RandomString(8),
+		},
+		MediaType: v1.MediaTypeDescriptor,
+		Path:      RandomString(8),
+		Size:      42,
+	}
+
+	err := metadata.PutManifest(name, digest, wantMetadata)
+	RequireNoError(t, err)
+
+	gotMetadata, err := metadata.GetManifest(name, digest)
+
+	AssertStructsEqual(t, gotMetadata, wantMetadata)
+}

--- a/testing/assert.go
+++ b/testing/assert.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/textproto"
 	"slices"
@@ -154,11 +155,22 @@ func AssertIndex(t *testing.T, got, want *v1.Index) bool {
 	}
 
 	for i := range got.Manifests {
-		gotDigest := got.Manifests[i].Digest
-		wantDigest := want.Manifests[i].Digest
+		gotDescriptor := got.Manifests[i]
+		wantDescriptor := want.Manifests[i]
+
+		gotDigest := gotDescriptor.Digest
+		wantDigest := wantDescriptor.Digest
 
 		if gotDigest != wantDigest {
-			t.Errorf("wrong digest value; got %q, want %q", gotDigest, wantDigest)
+			t.Errorf("wrong digest value in descriptor; got %q, want %q", gotDigest, wantDigest)
+			return false
+		}
+
+		gotAnnotations := gotDescriptor.Annotations
+		wantAnnotations := wantDescriptor.Annotations
+
+		if !maps.Equal(gotAnnotations, wantAnnotations) {
+			t.Errorf("descriptor annotations do not match; got %v, want %q", gotAnnotations, wantAnnotations)
 			return false
 		}
 	}

--- a/testing/assert.go
+++ b/testing/assert.go
@@ -208,7 +208,7 @@ func AssertStructsEqual(t *testing.T, got, want any) bool {
 	t.Helper()
 
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("structs are not equal; got %+v, want %+v", got, want)
+		t.Errorf("structs are not equal;\ngot:\n%+v\nwant:\n%+v", got, want)
 		return false
 	}
 

--- a/testing/assert.go
+++ b/testing/assert.go
@@ -155,6 +155,9 @@ func AssertIndex(t *testing.T, got, want *v1.Index) bool {
 		return false
 	}
 
+	slices.SortStableFunc(got.Manifests, descriptorSortFunc)
+	slices.SortStableFunc(want.Manifests, descriptorSortFunc)
+
 	for i := range got.Manifests {
 		gotDescriptor := got.Manifests[i]
 		wantDescriptor := want.Manifests[i]
@@ -217,4 +220,14 @@ func AssertStructsEqual(t *testing.T, got, want any) bool {
 
 func httpStatusText(code int) string {
 	return fmt.Sprintf("%d %s", code, http.StatusText(code))
+}
+
+func descriptorSortFunc(a, b v1.Descriptor) int {
+	if a.Digest.String() < b.Digest.String() {
+		return -1
+	}
+	if a.Digest.String() > b.Digest.String() {
+		return 1
+	}
+	return 0
 }

--- a/testing/assert.go
+++ b/testing/assert.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net/http"
 	"net/textproto"
+	"reflect"
 	"slices"
 	"testing"
 
@@ -158,19 +159,7 @@ func AssertIndex(t *testing.T, got, want *v1.Index) bool {
 		gotDescriptor := got.Manifests[i]
 		wantDescriptor := want.Manifests[i]
 
-		gotDigest := gotDescriptor.Digest
-		wantDigest := wantDescriptor.Digest
-
-		if gotDigest != wantDigest {
-			t.Errorf("wrong digest value in descriptor; got %q, want %q", gotDigest, wantDigest)
-			return false
-		}
-
-		gotAnnotations := gotDescriptor.Annotations
-		wantAnnotations := wantDescriptor.Annotations
-
-		if !maps.Equal(gotAnnotations, wantAnnotations) {
-			t.Errorf("descriptor annotations do not match; got %v, want %q", gotAnnotations, wantAnnotations)
+		if !AssertStructsEqual(t, gotDescriptor, wantDescriptor) {
 			return false
 		}
 	}
@@ -189,18 +178,40 @@ func AssertEqual[T comparable](t *testing.T, got, want T) bool {
 	return true
 }
 
-func AssertSlicesEqual[S ~[]E, E comparable](t *testing.T, s1 S, s2 S) bool {
+func AssertSlicesEqual[S ~[]E, E comparable](t *testing.T, got S, wamt S) bool {
 	t.Helper()
 
-	if len(s1) != len(s2) {
-		t.Errorf("slices are of unequal length; got %d, want %d", len(s2), len(s1))
+	if len(got) != len(wamt) {
+		t.Errorf("slices are of unequal length; got %d, want %d", len(wamt), len(got))
 		return false
 	}
 
-	if !slices.Equal(s1, s2) {
-		t.Errorf("slices are not equal; got %v, want %v", s2, s1)
+	if !slices.Equal(got, wamt) {
+		t.Errorf("slices are not equal; got %v, want %v", wamt, got)
 		return false
 	}
+	return true
+}
+
+func AssertMapsEqual[M1, M2 ~map[K]V, K, V comparable](t *testing.T, got M1, want M2) bool {
+	t.Helper()
+
+	if !maps.Equal(got, want) {
+		t.Errorf("maps are not equal; got %+v, want %+v", got, want)
+		return false
+	}
+
+	return true
+}
+
+func AssertStructsEqual(t *testing.T, got, want any) bool {
+	t.Helper()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("structs are not equal; got %+v, want %+v", got, want)
+		return false
+	}
+
 	return true
 }
 

--- a/testing/conformance/content_discovery_test.go
+++ b/testing/conformance/content_discovery_test.go
@@ -26,7 +26,7 @@ func TestContentDiscovery(t *testing.T) {
 		repository := RandomName()
 		digest := RandomDigest()
 		tags := make([]string, 50)
-		for i := 0; i < len(tags); i++ {
+		for i := range len(tags) {
 			tags[i] = RandomVersion()
 		}
 

--- a/testing/random.go
+++ b/testing/random.go
@@ -108,16 +108,13 @@ type Referrer struct {
 func GenerateReferrersWithIndex(t *testing.T, subject digest.Digest) (*v1.Index, []*Referrer) {
 	t.Helper()
 
-	idx := v1.Index{
-		Manifests: make([]v1.Descriptor, 0),
-	}
-
+	idx := v1.Index{Manifests: make([]v1.Descriptor, 0)}
 	referrers := make([]*Referrer, 0)
 
-	imageManifest := v1.Manifest{
+	manifest := v1.Manifest{
 		Annotations: map[string]string{
 			"test.case/number":      "0",
-			"test.case/description": "image manifest with an artifactType set",
+			"test.case/description": "image manifest with an artifact type set",
 		},
 		MediaType:    v1.MediaTypeImageManifest,
 		ArtifactType: "application/vnd.example+type",
@@ -126,23 +123,100 @@ func GenerateReferrersWithIndex(t *testing.T, subject digest.Digest) (*v1.Index,
 		},
 	}
 
-	imageManifestContent, err := json.Marshal(&imageManifest)
-	RequireNoError(t, err)
-
-	imageManifestDigest := digest.FromBytes(imageManifestContent)
-
-	referrers = append(referrers, &Referrer{
-		Digest:  imageManifestDigest,
-		Content: imageManifestContent,
+	referrers = appendReferrer(&idx, referrers, manifest, v1.Descriptor{
+		ArtifactType: manifest.ArtifactType,
+		MediaType:    manifest.MediaType,
+		Annotations:  manifest.Annotations,
 	})
 
-	idx.Manifests = append(idx.Manifests, v1.Descriptor{
-		ArtifactType: imageManifest.ArtifactType,
-		MediaType:    imageManifest.MediaType,
-		Annotations:  imageManifest.Annotations,
-		Digest:       imageManifestDigest,
-		Size:         int64(len(imageManifestContent)),
+	manifest = v1.Manifest{
+		Annotations: map[string]string{
+			"test.case/number":      "1",
+			"test.case/description": "image manifest without an artifact type set",
+		},
+		MediaType: v1.MediaTypeImageManifest,
+		Config: v1.Descriptor{
+			MediaType: v1.MediaTypeImageConfig,
+		},
+		Subject: &v1.Descriptor{
+			Digest: subject,
+		},
+	}
+
+	referrers = appendReferrer(&idx, referrers, manifest, v1.Descriptor{
+		MediaType:    manifest.MediaType,
+		ArtifactType: manifest.Config.MediaType,
+		Annotations:  manifest.Annotations,
+	})
+
+	manifest = v1.Manifest{
+		ArtifactType: "application/vnd.example.index+type",
+		Annotations: map[string]string{
+			"test.case/number":      "2",
+			"test.case/description": "index manifest with an artifact type set",
+		},
+		MediaType: v1.MediaTypeImageIndex,
+		Subject: &v1.Descriptor{
+			Digest: subject,
+		},
+	}
+
+	referrers = appendReferrer(&idx, referrers, manifest, v1.Descriptor{
+		MediaType:    manifest.MediaType,
+		ArtifactType: manifest.ArtifactType,
+		Annotations:  manifest.Annotations,
+	})
+
+	manifest = v1.Manifest{
+		Annotations: map[string]string{
+			"test.case/number":      "3",
+			"test.case/description": "index manifest without an artifact type set",
+		},
+		MediaType: v1.MediaTypeImageIndex,
+		Subject: &v1.Descriptor{
+			Digest: subject,
+		},
+	}
+
+	referrers = appendReferrer(&idx, referrers, manifest, v1.Descriptor{
+		MediaType:   manifest.MediaType,
+		Annotations: manifest.Annotations,
+	})
+
+	manifest = v1.Manifest{
+		Annotations: map[string]string{
+			"test.case/number":      "4",
+			"test.case/description": "index manifest without an artifact type set, but with a config mediaType",
+		},
+		MediaType: v1.MediaTypeImageIndex,
+		Config: v1.Descriptor{
+			MediaType: v1.MediaTypeImageConfig,
+		},
+		Subject: &v1.Descriptor{
+			Digest: subject,
+		},
+	}
+
+	referrers = appendReferrer(&idx, referrers, manifest, v1.Descriptor{
+		MediaType:   manifest.MediaType,
+		Annotations: manifest.Annotations,
 	})
 
 	return &idx, referrers
+}
+
+func appendReferrer(idx *v1.Index, referrers []*Referrer, manifest v1.Manifest, descriptor v1.Descriptor) []*Referrer {
+	content, _ := json.Marshal(&manifest)
+	descriptor.Size = int64(len(content))
+
+	digest := digest.FromBytes(content)
+	descriptor.Digest = digest
+
+	idx.Manifests = append(idx.Manifests, descriptor)
+	referrers = append(referrers, &Referrer{
+		Content: content,
+		Digest:  digest,
+	})
+
+	return referrers
 }

--- a/testing/random.go
+++ b/testing/random.go
@@ -14,6 +14,12 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+const (
+	charset = "0123456789" +
+		"abcdefghijklmnopqrstuvwxyz" +
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+)
+
 func RandomName() string {
 	return strings.Replace(namesgenerator.GetRandomName(0), "_", "/", -1)
 }
@@ -22,6 +28,14 @@ func RandomContents(length int64) []byte {
 	data := make([]byte, length)
 	crand.Read(data)
 	return data
+}
+
+func RandomString(length int) string {
+	data := make([]byte, length)
+	for i := range data {
+		data[i] = charset[rand.IntN(len(charset))]
+	}
+	return string(data)
 }
 
 func RandomDigest() digest.Digest {
@@ -34,7 +48,7 @@ func RandomManifest() (id digest.Digest, manifest *v1.Manifest, content []byte) 
 		Annotations: map[string]string{
 			// Small amount of random content to make sure that
 			// every generated manifest has a unique digest.
-			"random": string(RandomContents(32)),
+			"random": RandomString(8),
 		},
 	}
 	content, _ = json.Marshal(manifest)
@@ -52,7 +66,7 @@ func RandomManifestWithSubject(subjDigest digest.Digest, subject *v1.Manifest) (
 		Annotations: map[string]string{
 			// Small amount of random content to make sure that
 			// every generated manifest has a unique digest.
-			"random": string(RandomContents(32)),
+			"random": RandomString(8),
 		},
 	}
 	content, _ = json.Marshal(manifest)
@@ -101,6 +115,10 @@ func GenerateReferrersWithIndex(t *testing.T, subject digest.Digest) (*v1.Index,
 	referrers := make([]*Referrer, 0)
 
 	referrerManifest := v1.Manifest{
+		Annotations: map[string]string{
+			"manifest": "non-special",
+			"random":   RandomString(12),
+		},
 		Subject: &v1.Descriptor{
 			Digest: subject,
 		},
@@ -117,7 +135,8 @@ func GenerateReferrersWithIndex(t *testing.T, subject digest.Digest) (*v1.Index,
 	})
 
 	idx.Manifests = append(idx.Manifests, v1.Descriptor{
-		Digest: referrDigest,
+		Annotations: referrerManifest.Annotations,
+		Digest:      referrDigest,
 	})
 
 	return &idx, referrers

--- a/testing/random.go
+++ b/testing/random.go
@@ -137,6 +137,7 @@ func GenerateReferrersWithIndex(t *testing.T, subject digest.Digest) (*v1.Index,
 	idx.Manifests = append(idx.Manifests, v1.Descriptor{
 		Annotations: referrerManifest.Annotations,
 		Digest:      referrDigest,
+		Size:        int64(len(referrerContent)),
 	})
 
 	return &idx, referrers

--- a/testing/random.go
+++ b/testing/random.go
@@ -114,30 +114,33 @@ func GenerateReferrersWithIndex(t *testing.T, subject digest.Digest) (*v1.Index,
 
 	referrers := make([]*Referrer, 0)
 
-	referrerManifest := v1.Manifest{
+	imageManifest := v1.Manifest{
 		Annotations: map[string]string{
-			"manifest": "non-special",
-			"random":   RandomString(12),
+			"test.case/number":      "0",
+			"test.case/description": "image manifest with an artifactType set",
 		},
+		ArtifactType: "application/vnd.example+type",
 		Subject: &v1.Descriptor{
 			Digest: subject,
 		},
 	}
 
-	referrerContent, err := json.Marshal(&referrerManifest)
+	imageManifestContent, err := json.Marshal(&imageManifest)
 	RequireNoError(t, err)
 
-	referrDigest := digest.FromBytes(referrerContent)
+	imageManifestDigest := digest.FromBytes(imageManifestContent)
 
 	referrers = append(referrers, &Referrer{
-		Digest:  referrDigest,
-		Content: referrerContent,
+		Digest:  imageManifestDigest,
+		Content: imageManifestContent,
 	})
 
 	idx.Manifests = append(idx.Manifests, v1.Descriptor{
-		Annotations: referrerManifest.Annotations,
-		Digest:      referrDigest,
-		Size:        int64(len(referrerContent)),
+		ArtifactType: imageManifest.ArtifactType,
+		MediaType:    imageManifest.MediaType,
+		Annotations:  imageManifest.Annotations,
+		Digest:       imageManifestDigest,
+		Size:         int64(len(imageManifestContent)),
 	})
 
 	return &idx, referrers

--- a/testing/random.go
+++ b/testing/random.go
@@ -119,6 +119,7 @@ func GenerateReferrersWithIndex(t *testing.T, subject digest.Digest) (*v1.Index,
 			"test.case/number":      "0",
 			"test.case/description": "image manifest with an artifactType set",
 		},
+		MediaType:    v1.MediaTypeImageManifest,
 		ArtifactType: "application/vnd.example+type",
 		Subject: &v1.Descriptor{
 			Digest: subject,


### PR DESCRIPTION
Persist more manifest metadata into the metadata store. Expand listing referrers to return said metadata.