### PR TITLE
Blobstore Redesign

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -32,12 +32,12 @@ func (s *registryService) GetBlob(repository, id string) (io.Reader, error) {
 		return nil, ErrBlobUnknown
 	}
 
-	path, err := s.metadata.GetBlob(repository, digest)
+	_, err = s.metadata.GetBlob(repository, digest)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.blobs.Reader(path)
+	return s.blobs.BlobReader(digest)
 }
 
 func (s *registryService) DeleteBlob(repository, id string) error {

--- a/blobs.go
+++ b/blobs.go
@@ -13,12 +13,12 @@ func (s *registryService) StatBlob(repository, id string) (*FileInfo, error) {
 		return nil, ErrBlobUnknown
 	}
 
-	path, err := s.metadata.GetBlob(repository, digest)
+	_, err = s.metadata.GetBlob(repository, digest)
 	if err != nil {
 		return nil, err
 	}
 
-	info, err := s.blobs.Stat(path)
+	info, err := s.blobs.StatBlob(digest)
 	if errors.Is(err, ErrFileNotFound) {
 		return nil, ErrBlobUnknown
 	}

--- a/blobs_test.go
+++ b/blobs_test.go
@@ -20,7 +20,7 @@ func TestStatBlob(t *testing.T) {
 	// TODO: This is not good.
 	path := fmt.Sprintf("blobs/%s/%s/%s", digest.Algorithm(), digest.Encoded()[0:2], digest.Encoded())
 
-	blobs.Put(path, content)
+	blobs.PutBlob(digest, content)
 	metadata.PutBlob(name, digest, path)
 
 	t.Run("Known blob returns no error", func(t *testing.T) {
@@ -46,7 +46,7 @@ func TestGetBlob(t *testing.T) {
 	digest, content := RandomBlob(32)
 	path := digest.Encoded()
 
-	blobs.Put(path, content)
+	blobs.PutBlob(digest, content)
 	metadata.PutBlob(name, digest, path)
 
 	t.Run("Known blob returns content and no error", func(t *testing.T) {
@@ -77,7 +77,7 @@ func TestDeleteBlob(t *testing.T) {
 
 	t.Run("A deleted blob is not retrievable", func(t *testing.T) {
 		metadata.PutBlob(name, digest, path)
-		blobs.Put(path, content)
+		blobs.PutBlob(digest, content)
 
 		_, err := service.GetBlob(name, digest.String())
 		RequireNoError(t, err)

--- a/blobs_test.go
+++ b/blobs_test.go
@@ -1,6 +1,7 @@
 package cascade_test
 
 import (
+	"fmt"
 	"io"
 	"testing"
 
@@ -16,7 +17,8 @@ func TestStatBlob(t *testing.T) {
 
 	name := RandomName()
 	digest, content := RandomBlob(32 * 1024)
-	path := digest.Encoded()
+	// TODO: This is not good.
+	path := fmt.Sprintf("blobs/%s/%s/%s", digest.Algorithm(), digest.Encoded()[0:2], digest.Encoded())
 
 	blobs.Put(path, content)
 	metadata.PutBlob(name, digest, path)

--- a/blobs_test.go
+++ b/blobs_test.go
@@ -1,7 +1,6 @@
 package cascade_test
 
 import (
-	"fmt"
 	"io"
 	"testing"
 
@@ -17,11 +16,9 @@ func TestStatBlob(t *testing.T) {
 
 	name := RandomName()
 	digest, content := RandomBlob(32 * 1024)
-	// TODO: This is not good.
-	path := fmt.Sprintf("blobs/%s/%s/%s", digest.Algorithm(), digest.Encoded()[0:2], digest.Encoded())
 
 	blobs.PutBlob(digest, content)
-	metadata.PutBlob(name, digest, path)
+	metadata.PutBlob(name, digest)
 
 	t.Run("Known blob returns no error", func(t *testing.T) {
 		_, err := service.StatBlob(name, digest.String())
@@ -44,10 +41,9 @@ func TestGetBlob(t *testing.T) {
 
 	name := RandomName()
 	digest, content := RandomBlob(32)
-	path := digest.Encoded()
 
 	blobs.PutBlob(digest, content)
-	metadata.PutBlob(name, digest, path)
+	metadata.PutBlob(name, digest)
 
 	t.Run("Known blob returns content and no error", func(t *testing.T) {
 		r, err := service.GetBlob(name, digest.String())
@@ -73,10 +69,9 @@ func TestDeleteBlob(t *testing.T) {
 
 	name := RandomName()
 	digest, content := RandomBlob(32)
-	path := digest.String()
 
 	t.Run("A deleted blob is not retrievable", func(t *testing.T) {
-		metadata.PutBlob(name, digest, path)
+		metadata.PutBlob(name, digest)
 		blobs.PutBlob(digest, content)
 
 		_, err := service.GetBlob(name, digest.String())

--- a/manifests.go
+++ b/manifests.go
@@ -3,7 +3,6 @@ package cascade
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -65,9 +64,7 @@ func (s *registryService) PutManifest(repository, reference string, content []by
 		subject = manifest.Subject.Digest
 	}
 
-	path := fmt.Sprintf("blobs/%s/%s/%s", digest.Algorithm(), digest.Encoded()[0:2], digest.Encoded())
-
-	err = s.blobs.Put(path, content)
+	err = s.blobs.PutBlob(digest, content)
 	if err != nil {
 		return "", err
 	}
@@ -76,7 +73,6 @@ func (s *registryService) PutManifest(repository, reference string, content []by
 		Annotations:  manifest.Annotations,
 		ArtifactType: manifest.ArtifactType,
 		MediaType:    manifest.MediaType,
-		Path:         path,
 		Subject:      subject,
 		Size:         int64(len(content)),
 	}
@@ -96,15 +92,9 @@ func (s *registryService) DeleteManifest(repository, id string) error {
 		return ErrManifestUnknown
 	}
 
-	meta, err := s.metadata.GetManifest(repository, digest)
+	_, err = s.metadata.GetManifest(repository, digest)
 	if err != nil {
 		return ErrManifestUnknown
-	}
-
-	// TODO: Shouldn't do this. Manifests could be shared between repos.
-	err = s.blobs.Delete(meta.Path)
-	if err != nil {
-		return err
 	}
 
 	return s.metadata.DeleteManifest(repository, digest)

--- a/manifests.go
+++ b/manifests.go
@@ -15,12 +15,12 @@ func (s *registryService) StatManifest(repository, id string) (*FileInfo, error)
 		return nil, ErrManifestUnknown
 	}
 
-	meta, err := s.metadata.GetManifest(repository, digest)
+	_, err = s.metadata.GetManifest(repository, digest)
 	if err != nil {
 		return nil, ErrManifestUnknown
 	}
 
-	info, err := s.blobs.Stat(meta.Path)
+	info, err := s.blobs.StatBlob(digest)
 	if errors.Is(err, ErrFileNotFound) {
 		return nil, ErrManifestUnknown
 	}
@@ -101,6 +101,7 @@ func (s *registryService) DeleteManifest(repository, id string) error {
 		return ErrManifestUnknown
 	}
 
+	// TODO: Shouldn't do this. Manifests could be shared between repos.
 	err = s.blobs.Delete(meta.Path)
 	if err != nil {
 		return err

--- a/manifests.go
+++ b/manifests.go
@@ -39,7 +39,7 @@ func (s *registryService) GetManifest(repository, id string) (*ManifestMetadata,
 		return nil, nil, ErrManifestUnknown
 	}
 
-	content, err := s.blobs.Get(meta.Path)
+	content, err := s.blobs.GetBlob(digest)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/manifests_test.go
+++ b/manifests_test.go
@@ -49,7 +49,7 @@ func TestStatManifest(t *testing.T) {
 }
 
 func TestGetManifest(t *testing.T) {
-	service, _, _ := newTestRegistry()
+	service, metadata, blobs := newTestRegistry()
 
 	name := RandomName()
 	manifest, _ := json.Marshal(v1.Manifest{MediaType: v1.MediaTypeImageLayer})
@@ -62,6 +62,28 @@ func TestGetManifest(t *testing.T) {
 		_, got, err := service.GetManifest(name, digest.String())
 		AssertNoError(t, err)
 		AssertSlicesEqual(t, got, manifest)
+	})
+
+	t.Run("Metadata is correctly retrieved", func(t *testing.T) {
+		name := RandomName()
+		want := cascade.ManifestMetadata{
+			Annotations: map[string]string{
+				RandomString(6): RandomString(32),
+			},
+			ArtifactType: RandomString(6),
+			MediaType:    RandomString(6),
+			Size:         42,
+			// Subject field is not persisted, only used for creating links.
+		}
+
+		err := metadata.PutManifest(name, digest, &want)
+		RequireNoError(t, err)
+		err = blobs.PutBlob(digest, manifest)
+		RequireNoError(t, err)
+
+		got, _, err := service.GetManifest(name, digest.String())
+		AssertNoError(t, err)
+		AssertStructsEqual(t, got, &want)
 	})
 
 	t.Run("returns ErrManifestUnknown on unknown manifest", func(t *testing.T) {

--- a/manifests_test.go
+++ b/manifests_test.go
@@ -11,20 +11,17 @@ import (
 )
 
 func TestStatManifest(t *testing.T) {
-	service, metadata, blobs := newTestRegistry()
+	service, _, _ := newTestRegistry()
 
 	name := RandomName()
 	digest, _, content := RandomManifest()
 
-	path := digest.String()
-	blobs.Put(path, content)
-	metadata.PutManifest(name, digest, &cascade.ManifestMetadata{
-		Path: path,
-	})
+	_, err := service.PutManifest(name, digest.String(), content)
+	RequireNoError(t, err)
 
 	t.Run("Returns FileInfo with expected size on known manifest", func(t *testing.T) {
 		info, err := service.StatManifest(name, digest.String())
-		AssertNoError(t, err)
+		RequireNoError(t, err)
 
 		got := info.Size
 		want := int64(len(content))

--- a/manifests_test.go
+++ b/manifests_test.go
@@ -49,18 +49,14 @@ func TestStatManifest(t *testing.T) {
 }
 
 func TestGetManifest(t *testing.T) {
-	service, metadata, blobs := newTestRegistry()
+	service, _, _ := newTestRegistry()
 
 	name := RandomName()
 	manifest, _ := json.Marshal(v1.Manifest{MediaType: v1.MediaTypeImageLayer})
 	digest := digest.FromBytes(manifest)
 
-	path := digest.String()
-	blobs.Put(path, manifest)
-	metadata.PutManifest(name, digest, &cascade.ManifestMetadata{
-		Path:      path,
-		MediaType: v1.MediaTypeImageLayer,
-	})
+	_, err := service.PutManifest(name, digest.String(), manifest)
+	RequireNoError(t, err)
 
 	t.Run("Retrieve an existing manifest", func(t *testing.T) {
 		_, got, err := service.GetManifest(name, digest.String())

--- a/server/blob_uploads.go
+++ b/server/blob_uploads.go
@@ -99,6 +99,8 @@ func (s *Server) streamedUploadHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
 }
 
+// TODO: This should be split up into multiple methods, with the correct method
+// being selected in blobsUploadHandler, just like choosing between chunked and streaming uploads.
 func (s *Server) closeUploadHandler(w http.ResponseWriter, r *http.Request) {
 	repository := r.PathValue("repository")
 	reference := r.PathValue("reference")

--- a/server/manifests_test.go
+++ b/server/manifests_test.go
@@ -84,7 +84,6 @@ func TestGetManifests(t *testing.T) {
 	digest, manifest, content := RandomManifest()
 	meta := &cascade.ManifestMetadata{
 		MediaType: manifest.MediaType,
-		Path:      digest.String(),
 	}
 	tag := RandomVersion()
 

--- a/service.go
+++ b/service.go
@@ -53,7 +53,9 @@ type (
 	UploadSession struct {
 		ID uuid.UUID
 		// TODO: This should not be here, as it's an HTTP implementation detail.
-		Location  string
+		Location string
+		// TODO: Will go away with the blob store refactor, as uploads
+		// are saved based on the session ID.
 		BlobPath  string
 		StartDate time.Time
 		// TODO: Could we make this a hash.Hash and make it easier?

--- a/store.go
+++ b/store.go
@@ -19,6 +19,7 @@ type (
 	// I do like having the option of just creating repos on the fly, though...
 	MetadataStore interface {
 		GetBlob(repository string, digest digest.Digest) (string, error)
+		// TODO: path parameter will be removed after BlobStore redesign.
 		PutBlob(repository string, digest digest.Digest, path string) error
 		DeleteBlob(repository string, digest digest.Digest) error
 
@@ -42,35 +43,35 @@ type (
 	// Implementations of this interface are responsible for deciding how data is persisted.
 	// Blobs must be retrievable by their digest, and uploads by their session ID.
 	BlobStore interface {
-		// Put writes content to the given path. Intended for smaller blobs that
-		// must be fully read into memory server-side, like manifests.
-		// Unlike Writer, Put does not append and always writes the entire blob.
-		Put(path string, content []byte) error
-		// Reader returns an io.Reader that can be used to read a blob.
-		Reader(path string) (io.Reader, error)
-		// Writer returns an io.Writer to write to a blob. Blobs are always appended to.
-		// If a blob must be truncated, delete it first.
-		Writer(path string) (io.Writer, error)
-		// Delete removes the blob at the given path.
-		Delete(path string) error
-		// Move moves the blob from the source path to the destination path.
-		// This may effectively be a rename on some backends.
-		Move(sourcePath, destinationPath string) error
-
 		// StatBlob returns basic file info about the blob with the given digest.
 		StatBlob(id digest.Digest) (*FileInfo, error)
 		// GetBlob returns the blob at the given path. Intended for smaller blobs that
 		// must be fully read into memory server-side, like manifests.
 		GetBlob(id digest.Digest) ([]byte, error)
+		// BlobReader returns an io.Reader that can be used to read a blob in a streaming fashion.
+		BlobReader(id digest.Digest) (io.Reader, error)
+		// PutBlob writes content to the given path. Intended for smaller blobs that
+		// must be fully read into memory server-side, like manifests.
+		// Unlike Writer, Put does not append and always writes the entire blob.
+		PutBlob(id digest.Digest, content []byte) error
+		// DeleteBlob removes a blob from the blobstore.
+		DeleteBlob(id digest.Digest) error
+
 		// StatBlob returns basic file info about the upload with the given UUID.
 		StatUpload(id uuid.UUID) (*FileInfo, error)
-
-		// PutBlob: Replaces Put - Used in PutManifest
-		// DeleteBlob: Replaces Delete - Would be used by GC
-		// DeleteUpload: Replaces Delete - Would be used by GC or CloseUpload
-		// BlobReader: Replaces Reader - Used by GetBlob
-		// UploadWriter: Replaces Writer - Used by AppendUpload
-		// CloseUpload: Replaces Move - Used by CloseUpload
+		// InitUpload prepares the BlobStore to start an upload. In most implementations,
+		// it will create an empty file on the blob store that will later be appended.
+		InitUpload(id uuid.UUID) error
+		// UploadWriter returns an io.Writer to write to an initialized upload.
+		// Uploads are always appended to. If an upload fails or must be truncated
+		// a new session must be started instead.
+		UploadWriter(id uuid.UUID) (io.Writer, error)
+		// CloseUpload finishes an upload and makes its contents accessible in the blob store by its digest.
+		// In some implementations, this may effectively be a rename.
+		CloseUpload(id uuid.UUID, digest digest.Digest) error
+		// DeleteUpload removes an upload from the store.
+		// Intended for cleaning up expired or failed uploads.
+		DeleteUpload(id uuid.UUID) error
 	}
 
 	// Based (at least initially) on fs.FileInfo interface.

--- a/store.go
+++ b/store.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 
+	"github.com/gofrs/uuid/v5"
 	"github.com/opencontainers/go-digest"
 )
 
@@ -37,9 +38,10 @@ type (
 		DeleteUploadSession(repository string, id string) error
 	}
 
+	// BlobStore defines the interface for storing the actual data of the registry.
+	// Implementations of this interface are responsible for deciding how data is persisted.
+	// Blobs must be retrievable by their digest, and uploads by their session ID.
 	BlobStore interface {
-		// Stat returns basic file info about the blob at the given path.
-		Stat(path string) (*FileInfo, error)
 		// Get returns the blob at the given path. Intended for smaller blobs that
 		// must be fully read into memory server-side, like manifests.
 		Get(path string) ([]byte, error)
@@ -57,6 +59,20 @@ type (
 		// Move moves the blob from the source path to the destination path.
 		// This may effectively be a rename on some backends.
 		Move(sourcePath, destinationPath string) error
+
+		// StatBlob returns basic file info about the blob with the given digest.
+		StatBlob(id digest.Digest) (*FileInfo, error)
+
+		// StatBlob returns basic file info about the upload with the given UUID.
+		StatUpload(id uuid.UUID) (*FileInfo, error)
+
+		// GetBlob: Replaces Get - Used in GetManifest
+		// PutBlob: Replaces Put - Used in PutManifest
+		// DeleteBlob: Replaces Delete - Would be used by GC
+		// DeleteUpload: Replaces Delete - Would be used by GC or CloseUpload
+		// BlobReader: Replaces Reader - Used by GetBlob
+		// UploadWriter: Replaces Writer - Used by AppendUpload
+		// CloseUpload: Replaces Move - Used by CloseUpload
 	}
 
 	// Based (at least initially) on fs.FileInfo interface.
@@ -70,8 +86,9 @@ type (
 		Annotations  map[string]string
 		ArtifactType string
 		MediaType    string
-		Path         string
-		Subject      digest.Digest
-		Size         int64
+		// TODO: Will go away?
+		Path    string
+		Subject digest.Digest
+		Size    int64
 	}
 )

--- a/store.go
+++ b/store.go
@@ -42,9 +42,6 @@ type (
 	// Implementations of this interface are responsible for deciding how data is persisted.
 	// Blobs must be retrievable by their digest, and uploads by their session ID.
 	BlobStore interface {
-		// Get returns the blob at the given path. Intended for smaller blobs that
-		// must be fully read into memory server-side, like manifests.
-		Get(path string) ([]byte, error)
 		// Put writes content to the given path. Intended for smaller blobs that
 		// must be fully read into memory server-side, like manifests.
 		// Unlike Writer, Put does not append and always writes the entire blob.
@@ -62,11 +59,12 @@ type (
 
 		// StatBlob returns basic file info about the blob with the given digest.
 		StatBlob(id digest.Digest) (*FileInfo, error)
-
+		// GetBlob returns the blob at the given path. Intended for smaller blobs that
+		// must be fully read into memory server-side, like manifests.
+		GetBlob(id digest.Digest) ([]byte, error)
 		// StatBlob returns basic file info about the upload with the given UUID.
 		StatUpload(id uuid.UUID) (*FileInfo, error)
 
-		// GetBlob: Replaces Get - Used in GetManifest
 		// PutBlob: Replaces Put - Used in PutManifest
 		// DeleteBlob: Replaces Delete - Would be used by GC
 		// DeleteUpload: Replaces Delete - Would be used by GC or CloseUpload
@@ -86,7 +84,7 @@ type (
 		Annotations  map[string]string
 		ArtifactType string
 		MediaType    string
-		// TODO: Will go away?
+		// TODO: Will go away after BlobStore redesign
 		Path    string
 		Subject digest.Digest
 		Size    int64

--- a/store.go
+++ b/store.go
@@ -19,8 +19,7 @@ type (
 	// I do like having the option of just creating repos on the fly, though...
 	MetadataStore interface {
 		GetBlob(repository string, digest digest.Digest) (string, error)
-		// TODO: path parameter will be removed after BlobStore redesign.
-		PutBlob(repository string, digest digest.Digest, path string) error
+		PutBlob(repository string, digest digest.Digest) error
 		DeleteBlob(repository string, digest digest.Digest) error
 
 		GetManifest(repository string, digest digest.Digest) (*ManifestMetadata, error)
@@ -85,9 +84,7 @@ type (
 		Annotations  map[string]string
 		ArtifactType string
 		MediaType    string
-		// TODO: Will go away after BlobStore redesign
-		Path    string
-		Subject digest.Digest
-		Size    int64
+		Subject      digest.Digest
+		Size         int64
 	}
 )

--- a/store/inmemory/blob.go
+++ b/store/inmemory/blob.go
@@ -2,10 +2,18 @@ package inmemory
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"sync"
 
+	"github.com/gofrs/uuid/v5"
+	"github.com/opencontainers/go-digest"
 	"github.com/robinkb/cascade-registry"
+)
+
+const (
+	blobPathFormat   = "blobs/%s/%s/%s"
+	uploadPathFormat = "uploads/%s"
 )
 
 func NewBlobStore() cascade.BlobStore {
@@ -32,19 +40,14 @@ func (w *writer) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-func (s *blobStore) Stat(path string) (*cascade.FileInfo, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+func (s *blobStore) StatBlob(id digest.Digest) (*cascade.FileInfo, error) {
+	path := s.digestToPath(id)
+	return s.stat(path)
+}
 
-	data, ok := s.store[path]
-	if !ok {
-		return nil, cascade.ErrFileNotFound
-	}
-
-	return &cascade.FileInfo{
-		Name: path,
-		Size: int64(len(data)),
-	}, nil
+func (s *blobStore) StatUpload(id uuid.UUID) (*cascade.FileInfo, error) {
+	path := s.uuidToPath(id)
+	return s.stat(path)
 }
 
 func (s *blobStore) Get(path string) ([]byte, error) {
@@ -92,4 +95,27 @@ func (s *blobStore) Move(sourcePath, destinationPath string) error {
 
 	s.store[destinationPath] = s.store[sourcePath]
 	return nil
+}
+
+func (s *blobStore) digestToPath(id digest.Digest) string {
+	return fmt.Sprintf(blobPathFormat, id.Algorithm(), id.Encoded()[0:2], id.Encoded())
+}
+
+func (s *blobStore) uuidToPath(id uuid.UUID) string {
+	return fmt.Sprintf(uploadPathFormat, id.String())
+}
+
+func (s *blobStore) stat(path string) (*cascade.FileInfo, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	data, ok := s.store[path]
+	if !ok {
+		return nil, cascade.ErrFileNotFound
+	}
+
+	return &cascade.FileInfo{
+		Name: path,
+		Size: int64(len(data)),
+	}, nil
 }

--- a/store/inmemory/blob.go
+++ b/store/inmemory/blob.go
@@ -45,20 +45,21 @@ func (s *blobStore) StatBlob(id digest.Digest) (*cascade.FileInfo, error) {
 	return s.stat(path)
 }
 
-func (s *blobStore) StatUpload(id uuid.UUID) (*cascade.FileInfo, error) {
-	path := s.uuidToPath(id)
-	return s.stat(path)
-}
-
-func (s *blobStore) Get(path string) ([]byte, error) {
+func (s *blobStore) GetBlob(id digest.Digest) ([]byte, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
+	path := s.digestToPath(id)
 	data, ok := s.store[path]
 	if !ok {
 		return nil, cascade.ErrFileNotFound
 	}
 	return data, nil
+}
+
+func (s *blobStore) StatUpload(id uuid.UUID) (*cascade.FileInfo, error) {
+	path := s.uuidToPath(id)
+	return s.stat(path)
 }
 
 func (s *blobStore) Put(path string, content []byte) error {

--- a/store/inmemory/blob.go
+++ b/store/inmemory/blob.go
@@ -57,45 +57,64 @@ func (s *blobStore) GetBlob(id digest.Digest) ([]byte, error) {
 	return data, nil
 }
 
-func (s *blobStore) StatUpload(id uuid.UUID) (*cascade.FileInfo, error) {
-	path := s.uuidToPath(id)
-	return s.stat(path)
+func (s *blobStore) BlobReader(id digest.Digest) (io.Reader, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	path := s.digestToPath(id)
+	return bytes.NewBuffer(s.store[path]), nil
 }
 
-func (s *blobStore) Put(path string, content []byte) error {
+func (s *blobStore) PutBlob(id digest.Digest, content []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	path := s.digestToPath(id)
 	s.store[path] = content
 
 	return nil
 }
 
-func (s *blobStore) Reader(path string) (io.Reader, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	return bytes.NewBuffer(s.store[path]), nil
+func (s *blobStore) DeleteBlob(id digest.Digest) error {
+	path := s.digestToPath(id)
+	return s.delete(path)
 }
 
-func (s *blobStore) Writer(path string) (io.Writer, error) {
+func (s *blobStore) StatUpload(id uuid.UUID) (*cascade.FileInfo, error) {
+	path := s.uuidToPath(id)
+	return s.stat(path)
+}
+
+func (s *blobStore) InitUpload(id uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path := s.uuidToPath(id)
+	s.store[path] = []byte{}
+
+	return nil
+}
+
+func (s *blobStore) UploadWriter(id uuid.UUID) (io.Writer, error) {
+	path := s.uuidToPath(id)
 	return &writer{s, path}, nil
 }
 
-func (s *blobStore) Delete(path string) error {
+func (s *blobStore) CloseUpload(id uuid.UUID, digest digest.Digest) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	delete(s.store, path)
+	uploadPath := s.uuidToPath(id)
+	blobPath := s.digestToPath(digest)
+
+	s.store[blobPath] = s.store[uploadPath]
+	delete(s.store, uploadPath)
 	return nil
 }
 
-func (s *blobStore) Move(sourcePath, destinationPath string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.store[destinationPath] = s.store[sourcePath]
-	return nil
+func (s *blobStore) DeleteUpload(id uuid.UUID) error {
+	path := s.uuidToPath(id)
+	return s.delete(path)
 }
 
 func (s *blobStore) digestToPath(id digest.Digest) string {
@@ -119,4 +138,12 @@ func (s *blobStore) stat(path string) (*cascade.FileInfo, error) {
 		Name: path,
 		Size: int64(len(data)),
 	}, nil
+}
+
+func (s *blobStore) delete(path string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.store, path)
+	return nil
 }

--- a/store/inmemory/metadata.go
+++ b/store/inmemory/metadata.go
@@ -31,14 +31,11 @@ type (
 		annotations  map[string]string
 		artifactType string
 		mediaType    string
-		path         string
 		referrers    map[godigest.Digest]any
 		size         int64
 	}
 
-	blob struct {
-		path string
-	}
+	blob struct{}
 
 	// Named 'ttag' instead of 'tag', because otherwise
 	// this type would be shadowed by variables named 'tag'.
@@ -61,18 +58,16 @@ func (s *metadataStore) ensureRepositoryExists(name string) {
 
 func (s *metadataStore) GetBlob(repository string, digest godigest.Digest) (string, error) {
 	if repo, ok := s.repositories[repository]; ok {
-		if blob, ok := repo.blobs[digest.String()]; ok {
-			return blob.path, nil
+		if _, ok := repo.blobs[digest.String()]; ok {
+			return "", nil
 		}
 	}
 	return "", cascade.ErrBlobUnknown
 }
 
-func (s *metadataStore) PutBlob(repository string, digest godigest.Digest, path string) error {
+func (s *metadataStore) PutBlob(repository string, digest godigest.Digest) error {
 	s.ensureRepositoryExists(repository)
-	s.repositories[repository].blobs[digest.String()] = &blob{
-		path: path,
-	}
+	s.repositories[repository].blobs[digest.String()] = &blob{}
 	return nil
 }
 
@@ -88,7 +83,6 @@ func (s *metadataStore) GetManifest(repository string, digest godigest.Digest) (
 				Annotations:  manifest.annotations,
 				ArtifactType: manifest.artifactType,
 				MediaType:    manifest.mediaType,
-				Path:         manifest.path,
 				Size:         manifest.size,
 			}, nil
 		}
@@ -109,7 +103,6 @@ func (s *metadataStore) PutManifest(repository string, digest godigest.Digest, m
 	manifests.annotations = meta.Annotations
 	manifests.artifactType = meta.ArtifactType
 	manifests.mediaType = meta.MediaType
-	manifests.path = meta.Path
 	manifests.size = meta.Size
 
 	if meta.Subject != "" {

--- a/store/inmemory/metadata_test.go
+++ b/store/inmemory/metadata_test.go
@@ -21,7 +21,6 @@ func TestManifestMetadataPersistence(t *testing.T) {
 			"random": RandomString(8),
 		},
 		MediaType: v1.MediaTypeDescriptor,
-		Path:      RandomString(8),
 		Size:      42,
 	}
 

--- a/testing/conformance/pull_test.go
+++ b/testing/conformance/pull_test.go
@@ -57,7 +57,7 @@ func TestPull(t *testing.T) {
 		name := RandomName()
 		digest, blob := RandomBlob(32)
 
-		metadata.PutBlob(name, digest, digest.String())
+		metadata.PutBlob(name, digest)
 		blobs.PutBlob(digest, blob)
 
 		t.Run("GET request to an existing blob", func(t *testing.T) {

--- a/testing/conformance/pull_test.go
+++ b/testing/conformance/pull_test.go
@@ -90,10 +90,13 @@ func TestPull(t *testing.T) {
 			name := RandomName()
 			digest, blob := RandomBlob(32)
 
-			metadata.PutBlob(name, digest, digest.String())
-			blobs.Put(digest.String(), blob)
+			resp := client.InitUpload(name)
+			AssertResponseCode(t, resp, http.StatusAccepted)
+			location, err := resp.Location()
+			RequireNoError(t, err)
+			resp = client.CloseUploadWithContent(location, digest, blob, 0)
 
-			resp := client.CheckBlob(name, digest)
+			resp = client.CheckBlob(name, digest)
 
 			// A HEAD request to an existing blob URL MUST return 200 OK.
 			AssertResponseCode(t, resp, http.StatusOK)
@@ -117,12 +120,10 @@ func TestPull(t *testing.T) {
 			name := RandomName()
 			digest, _, content := RandomManifest()
 
-			metadata.PutManifest(name, digest, &cascade.ManifestMetadata{
-				Path: digest.String(),
-			})
-			blobs.Put(digest.String(), content)
+			resp := client.PutManifest(name, digest.String(), content)
+			AssertResponseCode(t, resp, http.StatusCreated)
 
-			resp := client.CheckManifestByDigest(name, digest)
+			resp = client.CheckManifestByDigest(name, digest)
 
 			// A HEAD request to an existing manifest URL MUST return 200 OK
 			AssertResponseCode(t, resp, http.StatusOK)

--- a/testing/conformance/pull_test.go
+++ b/testing/conformance/pull_test.go
@@ -27,13 +27,10 @@ func TestPull(t *testing.T) {
 
 			name := RandomName()
 			digest, manifest, content := RandomManifest()
-			metadata.PutManifest(name, digest, &cascade.ManifestMetadata{
-				Path:      digest.String(),
-				MediaType: manifest.MediaType,
-			})
-			blobs.Put(digest.String(), content)
+			resp := client.PutManifest(name, digest.String(), content)
+			AssertResponseCode(t, resp, http.StatusCreated)
 
-			resp := client.GetManifestByDigest(name, digest)
+			resp = client.GetManifestByDigest(name, digest)
 
 			// A GET request to an existing manifest URL MUST provide the expected manifest, with a response code that MUST be 200 OK.
 			AssertResponseCode(t, resp, http.StatusOK)

--- a/testing/conformance/pull_test.go
+++ b/testing/conformance/pull_test.go
@@ -58,7 +58,7 @@ func TestPull(t *testing.T) {
 		digest, blob := RandomBlob(32)
 
 		metadata.PutBlob(name, digest, digest.String())
-		blobs.Put(digest.String(), blob)
+		blobs.PutBlob(digest, blob)
 
 		t.Run("GET request to an existing blob", func(t *testing.T) {
 			client := NewTestClient(t, ts.URL)

--- a/uploads.go
+++ b/uploads.go
@@ -56,7 +56,7 @@ func (s *registryService) InitUpload(repository string) *UploadSession {
 		BlobPath:  path,
 	}
 
-	err = s.blobs.Put(path, []byte{})
+	err = s.blobs.InitUpload(id)
 	if err != nil {
 		panic(err)
 	}
@@ -90,7 +90,7 @@ func (s *registryService) AppendUpload(repository, sessionID string, r io.Reader
 		return err
 	}
 
-	w, err := s.blobs.Writer(session.BlobPath)
+	w, err := s.blobs.UploadWriter(session.ID)
 	if err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func (s *registryService) CloseUpload(repository, sessionID, digest string) erro
 
 	destPath := fmt.Sprintf("blobs/%s/%s/%s", calculatedId.Algorithm(), calculatedId.Encoded()[0:2], calculatedId.Encoded())
 
-	s.blobs.Move(session.BlobPath, destPath)
+	s.blobs.CloseUpload(session.ID, calculatedId)
 
 	return s.metadata.PutBlob(repository, calculatedId, destPath)
 }

--- a/uploads.go
+++ b/uploads.go
@@ -131,9 +131,8 @@ func (s *registryService) CloseUpload(repository, sessionID, digest string) erro
 		return ErrBlobUploadInvalid
 	}
 
-	destPath := fmt.Sprintf("blobs/%s/%s/%s", calculatedId.Algorithm(), calculatedId.Encoded()[0:2], calculatedId.Encoded())
-
+	// TODO: This can fail in real imeplementations, test it and check it.
 	s.blobs.CloseUpload(session.ID, calculatedId)
 
-	return s.metadata.PutBlob(repository, calculatedId, destPath)
+	return s.metadata.PutBlob(repository, calculatedId)
 }

--- a/uploads.go
+++ b/uploads.go
@@ -20,9 +20,7 @@ func (s *registryService) StatUpload(repository, sessionID string) (*FileInfo, e
 		return nil, err
 	}
 
-	path := fmt.Sprintf("uploads/%s", session.ID)
-
-	info, err := s.blobs.Stat(path)
+	info, err := s.blobs.StatUpload(session.ID)
 	if errors.Is(err, ErrFileNotFound) {
 		return nil, ErrBlobUploadUnknown
 	}
@@ -77,7 +75,7 @@ func (s *registryService) AppendUpload(repository, sessionID string, r io.Reader
 		return err
 	}
 
-	info, err := s.blobs.Stat(session.BlobPath)
+	info, err := s.blobs.StatUpload(session.ID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The old BlobStore interface was heavily based on Distribution's original StorageDriver interface. It was nice and generic, but:

1. It doesn't concisely communicate how the BlobStore is used and what it does.
2. It places the responsibility of how the BlobStore is laid out in the Service layer, based on the paths generated there.

The new interface is a bit longer and more verbose, and should be more flexible for whatever future backends may be implemented.

Still to do: Review and clean up some changes I made to tests.

Closes #10 