### PR TITLE
Resolve most linting errors

### DIFF
--- a/blobs_test.go
+++ b/blobs_test.go
@@ -17,8 +17,10 @@ func TestStatBlob(t *testing.T) {
 	name := RandomName()
 	digest, content := RandomBlob(32 * 1024)
 
-	blobs.PutBlob(digest, content)
-	metadata.PutBlob(name, digest)
+	err := blobs.PutBlob(digest, content)
+	RequireNoError(t, err)
+	err = metadata.PutBlob(name, digest)
+	RequireNoError(t, err)
 
 	t.Run("Known blob returns no error", func(t *testing.T) {
 		_, err := service.StatBlob(name, digest.String())
@@ -42,8 +44,10 @@ func TestGetBlob(t *testing.T) {
 	name := RandomName()
 	digest, content := RandomBlob(32)
 
-	blobs.PutBlob(digest, content)
-	metadata.PutBlob(name, digest)
+	err := blobs.PutBlob(digest, content)
+	RequireNoError(t, err)
+	err = metadata.PutBlob(name, digest)
+	RequireNoError(t, err)
 
 	t.Run("Known blob returns content and no error", func(t *testing.T) {
 		r, err := service.GetBlob(name, digest.String())
@@ -71,10 +75,12 @@ func TestDeleteBlob(t *testing.T) {
 	digest, content := RandomBlob(32)
 
 	t.Run("A deleted blob is not retrievable", func(t *testing.T) {
-		metadata.PutBlob(name, digest)
-		blobs.PutBlob(digest, content)
+		err := blobs.PutBlob(digest, content)
+		RequireNoError(t, err)
+		err = metadata.PutBlob(name, digest)
+		RequireNoError(t, err)
 
-		_, err := service.GetBlob(name, digest.String())
+		_, err = service.GetBlob(name, digest.String())
 		RequireNoError(t, err)
 
 		err = service.DeleteBlob(name, digest.String())

--- a/referrers_test.go
+++ b/referrers_test.go
@@ -72,6 +72,7 @@ func TestListReferrers(t *testing.T) {
 		RequireNoError(t, err)
 
 		got, err := service.ListReferrers(name, digest.String(), nil)
+		AssertNoError(t, err)
 		AssertIndex(t, got.Index, wantIndex)
 	})
 

--- a/server/blobs.go
+++ b/server/blobs.go
@@ -46,7 +46,7 @@ func (s *Server) getBlobsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
-	io.Copy(w, blob)
+	writeOrLog(io.Copy(w, blob))
 }
 
 func (s *Server) deleteBlobsHandler(w http.ResponseWriter, r *http.Request) {

--- a/server/manifests.go
+++ b/server/manifests.go
@@ -70,7 +70,7 @@ func (s *Server) getManifestsHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set(HeaderContentType, meta.MediaType)
 	w.WriteHeader(http.StatusOK)
-	w.Write(content)
+	writeOrLog(w.Write(content))
 }
 
 func (s *Server) putManifestsHandler(w http.ResponseWriter, r *http.Request) {
@@ -99,7 +99,9 @@ func (s *Server) putManifestsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	case cascade.ErrManifestInvalid:
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(NewErrorResponse(err.(cascade.Error)))
+		encodeOrLog(json.NewEncoder(w).Encode(
+			NewErrorResponse(err.(cascade.Error)),
+		))
 		return
 	case nil:
 	}
@@ -133,7 +135,7 @@ func (s *Server) deleteManifestsHandler(w http.ResponseWriter, r *http.Request) 
 		if err != nil {
 			if errors.Is(err, cascade.ErrManifestUnknown) {
 				w.WriteHeader(http.StatusNotFound)
-				json.NewEncoder(w).Encode(NewErrorResponse(err.(cascade.Error)))
+				encodeOrLog(json.NewEncoder(w).Encode(NewErrorResponse(err.(cascade.Error))))
 				return
 			}
 		}

--- a/server/referrers.go
+++ b/server/referrers.go
@@ -39,6 +39,6 @@ func (s *Server) listReferrersHandler(w http.ResponseWriter, r *http.Request) {
 		if len(referrers.AppliedFilters) > 0 {
 			w.Header().Set(HeaderOCIFiltersApplied, strings.Join(referrers.AppliedFilters, ","))
 		}
-		json.NewEncoder(w).Encode(referrers.Index)
+		encodeOrLog(json.NewEncoder(w).Encode(referrers.Index))
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"slices"
 	"strings"
@@ -110,7 +111,7 @@ func writeErrorResponse(w http.ResponseWriter, err error) {
 	}
 
 	w.WriteHeader(code)
-	json.NewEncoder(w).Encode(response)
+	encodeOrLog(json.NewEncoder(w).Encode(response))
 }
 
 func NewErrorResponse(err ...cascade.Error) *ErrorResponse {
@@ -130,4 +131,16 @@ func (e ErrorResponse) Error() string {
 	}
 
 	return strings.Join(errs, ", ")
+}
+
+func writeOrLog(_ any, err error) {
+	if err != nil {
+		log.Printf("error writing content to client: %s", err)
+	}
+}
+
+func encodeOrLog(err error) {
+	if err != nil {
+		log.Printf("error writing encoded content to client: %s", err)
+	}
 }

--- a/server/tags.go
+++ b/server/tags.go
@@ -37,5 +37,5 @@ func (s *Server) listTagsHandler(w http.ResponseWriter, r *http.Request) {
 		Tags: tags,
 	}
 
-	json.NewEncoder(w).Encode(response)
+	encodeOrLog(json.NewEncoder(w).Encode(response))
 }

--- a/store/inmemory/metadata_test.go
+++ b/store/inmemory/metadata_test.go
@@ -28,6 +28,6 @@ func TestManifestMetadataPersistence(t *testing.T) {
 	RequireNoError(t, err)
 
 	gotMetadata, err := metadata.GetManifest(name, digest)
-
+	AssertNoError(t, err)
 	AssertStructsEqual(t, gotMetadata, wantMetadata)
 }

--- a/tags_test.go
+++ b/tags_test.go
@@ -16,7 +16,8 @@ func TestGetTag(t *testing.T) {
 		digest := RandomDigest()
 		tag := "v1.2.3"
 
-		metadata.PutTag(name, tag, digest)
+		err := metadata.PutTag(name, tag, digest)
+		RequireNoError(t, err)
 
 		got, err := service.GetTag(name, tag)
 		AssertNoError(t, err)

--- a/testing/conformance/content_discovery_test.go
+++ b/testing/conformance/content_discovery_test.go
@@ -28,7 +28,8 @@ func TestContentDiscovery(t *testing.T) {
 		tags := RandomTags(50)
 
 		for _, tag := range tags {
-			metadata.PutTag(repository, tag, digest)
+			err := metadata.PutTag(repository, tag, digest)
+			RequireNoError(t, err)
 		}
 
 		// Sort the tags _after_ putting them into the registry,

--- a/testing/conformance/pull_test.go
+++ b/testing/conformance/pull_test.go
@@ -57,8 +57,10 @@ func TestPull(t *testing.T) {
 		name := RandomName()
 		digest, blob := RandomBlob(32)
 
-		metadata.PutBlob(name, digest)
-		blobs.PutBlob(digest, blob)
+		err := metadata.PutBlob(name, digest)
+		RequireNoError(t, err)
+		err = blobs.PutBlob(digest, blob)
+		RequireNoError(t, err)
 
 		t.Run("GET request to an existing blob", func(t *testing.T) {
 			client := NewTestClient(t, ts.URL)
@@ -92,6 +94,7 @@ func TestPull(t *testing.T) {
 			location, err := resp.Location()
 			RequireNoError(t, err)
 			resp = client.CloseUploadWithContent(location, digest, blob, 0)
+			AssertResponseCode(t, resp, http.StatusCreated)
 
 			resp = client.CheckBlob(name, digest)
 

--- a/testing/random.go
+++ b/testing/random.go
@@ -21,7 +21,7 @@ const (
 )
 
 func RandomName() string {
-	return strings.Replace(namesgenerator.GetRandomName(0), "_", "/", -1)
+	return strings.ReplaceAll(namesgenerator.GetRandomName(0), "_", "/")
 }
 
 func RandomContents(length int64) []byte {

--- a/testing/random.go
+++ b/testing/random.go
@@ -26,6 +26,7 @@ func RandomName() string {
 
 func RandomContents(length int64) []byte {
 	data := make([]byte, length)
+	// nolint: errcheck
 	crand.Read(data)
 	return data
 }

--- a/uploads.go
+++ b/uploads.go
@@ -131,8 +131,10 @@ func (s *registryService) CloseUpload(repository, sessionID, digest string) erro
 		return ErrBlobUploadInvalid
 	}
 
-	// TODO: This can fail in real imeplementations, test it and check it.
-	s.blobs.CloseUpload(session.ID, calculatedId)
+	err = s.blobs.CloseUpload(session.ID, calculatedId)
+	if err != nil {
+		return err
+	}
 
 	return s.metadata.PutBlob(repository, calculatedId)
 }


### PR DESCRIPTION
I want to adopt `golangci-lint` pretty soon as part of #21. This PR resolves most of the errors that it throws.

I did not yet fix the error handling in the `server` package, because its current implementation makes me sad. And that needs to be fixed in separate PR.