### PR TITLE
Clean up error handling in the HTTP layer

### DIFF
--- a/server/blob_uploads.go
+++ b/server/blob_uploads.go
@@ -39,7 +39,7 @@ func (s *Server) checkUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	info, err := s.service.StatUpload(repository, reference)
 	if err != nil {
-		writeErrorResponse(w, err)
+		errorHandler(w, r, err)
 		return
 	}
 
@@ -57,7 +57,7 @@ func (s *Server) chunkedUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	givenStart, givenEnd, err := parseContentRange(r.Header.Get(HeaderContentRange))
 	if err != nil {
-		writeErrorResponse(w, err)
+		errorHandler(w, r, err)
 		return
 	}
 
@@ -65,7 +65,7 @@ func (s *Server) chunkedUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	content, err := io.ReadAll(r.Body)
 	if err != nil {
-		writeErrorResponse(w, err)
+		errorHandler(w, r, err)
 		return
 	}
 
@@ -75,7 +75,7 @@ func (s *Server) chunkedUploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.service.AppendUpload(repository, reference, bytes.NewBuffer(content), givenStart); err != nil {
-		writeErrorResponse(w, err)
+		errorHandler(w, r, err)
 		return
 	}
 
@@ -90,7 +90,7 @@ func (s *Server) streamedUploadHandler(w http.ResponseWriter, r *http.Request) {
 	reference := r.PathValue("reference")
 
 	if err := s.service.AppendUpload(repository, reference, r.Body, 0); err != nil {
-		writeErrorResponse(w, err)
+		errorHandler(w, r, err)
 		return
 	}
 
@@ -122,14 +122,22 @@ func (s *Server) closeUploadHandler(w http.ResponseWriter, r *http.Request) {
 			var err error
 			offset, _, err = parseContentRange(contentRange)
 			if err != nil {
-				writeErrorResponse(w, err)
+				errorHandler(w, r, err)
 				return
 			}
 		}
 
-		content, _ := io.ReadAll(r.Body)
-		// TODO: Check this error
-		s.service.AppendUpload(repository, reference, bytes.NewBuffer(content), offset)
+		content, err := io.ReadAll(r.Body)
+		if err != nil {
+			errorHandler(w, r, err)
+			return
+		}
+
+		err = s.service.AppendUpload(repository, reference, bytes.NewBuffer(content), offset)
+		if err != nil {
+			errorHandler(w, r, err)
+			return
+		}
 	}
 
 	digest := r.URL.Query().Get("digest")
@@ -140,7 +148,7 @@ func (s *Server) closeUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	err := s.service.CloseUpload(repository, reference, digest)
 	if err != nil {
-		writeErrorResponse(w, err)
+		errorHandler(w, r, err)
 		return
 	}
 

--- a/server/blobs.go
+++ b/server/blobs.go
@@ -25,9 +25,7 @@ func (s *Server) statBlobsHandler(w http.ResponseWriter, r *http.Request) {
 
 	info, err := s.service.StatBlob(repository, digest)
 	if err != nil {
-		// TODO: This currently writes a body, even though HEAD responses
-		// should never write a body. Something to consider when this gets refactored.
-		writeErrorResponse(w, err)
+		errorHandler(w, r, err)
 		return
 	}
 
@@ -41,7 +39,7 @@ func (s *Server) getBlobsHandler(w http.ResponseWriter, r *http.Request) {
 
 	blob, err := s.service.GetBlob(repository, digest)
 	if err != nil {
-		writeErrorResponse(w, err)
+		errorHandler(w, r, err)
 		return
 	}
 
@@ -55,7 +53,7 @@ func (s *Server) deleteBlobsHandler(w http.ResponseWriter, r *http.Request) {
 
 	err := s.service.DeleteBlob(repository, digest)
 	if err != nil {
-		writeErrorResponse(w, err)
+		errorHandler(w, r, err)
 		return
 	}
 

--- a/server/manifests.go
+++ b/server/manifests.go
@@ -1,8 +1,6 @@
 package server
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -36,8 +34,7 @@ func (s *Server) statManifestsHandler(w http.ResponseWriter, r *http.Request) {
 		var err error
 		reference, err = s.service.GetTag(repository, reference)
 		if err != nil {
-			// TODO: Writes a body on a HEAD request while it shouldn't.
-			writeErrorResponse(w, err)
+			errorHandler(w, r, err)
 			return
 		}
 	}
@@ -45,7 +42,7 @@ func (s *Server) statManifestsHandler(w http.ResponseWriter, r *http.Request) {
 	info, err := s.service.StatManifest(repository, reference)
 	if err != nil {
 		// TODO: Writes a body on a HEAD request while it shouldn't.
-		writeErrorResponse(w, err)
+		errorHandler(w, r, err)
 		return
 	}
 
@@ -59,12 +56,17 @@ func (s *Server) getManifestsHandler(w http.ResponseWriter, r *http.Request) {
 
 	// If the reference is a tag, fetch the digest first.
 	if cascade.ValidateTag(reference) {
-		reference, _ = s.service.GetTag(repository, reference)
+		var err error
+		reference, err = s.service.GetTag(repository, reference)
+		if err != nil {
+			errorHandler(w, r, err)
+			return
+		}
 	}
 
 	meta, content, err := s.service.GetManifest(repository, reference)
 	if err != nil {
-		writeErrorResponse(w, err)
+		errorHandler(w, r, err)
 		return
 	}
 
@@ -79,7 +81,7 @@ func (s *Server) putManifestsHandler(w http.ResponseWriter, r *http.Request) {
 
 	data, err := io.ReadAll(r.Body)
 	if err != nil {
-		writeErrorResponse(w, err)
+		errorHandler(w, r, err)
 		return
 	}
 
@@ -87,23 +89,15 @@ func (s *Server) putManifestsHandler(w http.ResponseWriter, r *http.Request) {
 
 	if !cascade.ValidateTag(reference) {
 		if digest.String() != reference {
-			writeErrorResponse(w, cascade.ErrDigestInvalid)
+			errorHandler(w, r, cascade.ErrDigestInvalid)
 			return
 		}
 	}
 
 	subject, err := s.service.PutManifest(repository, digest.String(), data)
-	switch err {
-	default:
-		w.WriteHeader(http.StatusInternalServerError)
+	if err != nil {
+		errorHandler(w, r, err)
 		return
-	case cascade.ErrManifestInvalid:
-		w.WriteHeader(http.StatusBadRequest)
-		encodeOrLog(json.NewEncoder(w).Encode(
-			NewErrorResponse(err.(cascade.Error)),
-		))
-		return
-	case nil:
 	}
 
 	if subject != "" {
@@ -113,7 +107,7 @@ func (s *Server) putManifestsHandler(w http.ResponseWriter, r *http.Request) {
 	if cascade.ValidateTag(reference) {
 		err = s.service.PutTag(repository, reference, digest.String())
 		if err != nil {
-			writeErrorResponse(w, err)
+			errorHandler(w, r, err)
 			return
 		}
 	}
@@ -127,19 +121,22 @@ func (s *Server) deleteManifestsHandler(w http.ResponseWriter, r *http.Request) 
 	reference := r.PathValue("reference")
 
 	if cascade.ValidateTag(reference) {
-		s.service.DeleteTag(repository, reference)
-
-		w.WriteHeader(http.StatusAccepted)
-	} else {
-		err := s.service.DeleteManifest(repository, reference)
+		err := s.service.DeleteTag(repository, reference)
 		if err != nil {
-			if errors.Is(err, cascade.ErrManifestUnknown) {
-				w.WriteHeader(http.StatusNotFound)
-				encodeOrLog(json.NewEncoder(w).Encode(NewErrorResponse(err.(cascade.Error))))
-				return
-			}
+			errorHandler(w, r, err)
+			return
 		}
 
 		w.WriteHeader(http.StatusAccepted)
+		return
 	}
+
+	err := s.service.DeleteManifest(repository, reference)
+	if err != nil {
+		errorHandler(w, r, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusAccepted)
+
 }

--- a/server/referrers.go
+++ b/server/referrers.go
@@ -29,16 +29,14 @@ func (s *Server) listReferrersHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	referrers, err := s.service.ListReferrers(repository, digest, &opts)
-	switch err {
-	default:
-		w.WriteHeader(http.StatusInternalServerError)
-	case cascade.ErrDigestInvalid:
-		w.WriteHeader(http.StatusBadRequest)
-	case nil:
-		w.Header().Set(HeaderContentType, v1.MediaTypeImageIndex)
-		if len(referrers.AppliedFilters) > 0 {
-			w.Header().Set(HeaderOCIFiltersApplied, strings.Join(referrers.AppliedFilters, ","))
-		}
-		encodeOrLog(json.NewEncoder(w).Encode(referrers.Index))
+	if err != nil {
+		errorHandler(w, r, err)
+		return
 	}
+
+	w.Header().Set(HeaderContentType, v1.MediaTypeImageIndex)
+	if len(referrers.AppliedFilters) > 0 {
+		w.Header().Set(HeaderOCIFiltersApplied, strings.Join(referrers.AppliedFilters, ","))
+	}
+	encodeOrLog(json.NewEncoder(w).Encode(referrers.Index))
 }

--- a/server/server.go
+++ b/server/server.go
@@ -80,38 +80,56 @@ type (
 	}
 )
 
-// This is starting to feel like the wrong approach.
-// ErrDigestInvalid should definitely not result in a 404 in most cases.
-func writeErrorResponse(w http.ResponseWriter, err error) {
+func errorHandler(w http.ResponseWriter, r *http.Request, err error) {
 	var response *ErrorResponse
+	var cerr cascade.Error
 	code := http.StatusInternalServerError
 
-	switch {
-	case errors.Is(err, cascade.ErrBlobUnknown):
-		code = http.StatusNotFound
-		response = NewErrorResponse(err.(cascade.Error))
-	case errors.Is(err, cascade.ErrBlobUploadUnknown):
-		code = http.StatusNotFound
-		response = NewErrorResponse(err.(cascade.Error))
-	case errors.Is(err, cascade.ErrManifestUnknown):
-		code = http.StatusNotFound
-		response = NewErrorResponse(err.(cascade.Error))
-	case errors.Is(err, cascade.ErrManifestInvalid):
-		code = http.StatusBadRequest
-		response = NewErrorResponse(err.(cascade.Error))
-	case errors.Is(err, cascade.ErrDigestInvalid):
-		code = http.StatusBadRequest
-		response = NewErrorResponse(err.(cascade.Error))
-	case errors.Is(err, cascade.ErrBlobUploadInvalid):
-		code = http.StatusBadRequest
-		response = NewErrorResponse(err.(cascade.Error))
-	case errors.Is(err, cascade.ErrUploadOffsetInvalid):
-		code = http.StatusRequestedRangeNotSatisfiable
-		response = NewErrorResponse(err.(cascade.Error))
+	if errors.As(err, &cerr) {
+		switch {
+		// Standard Distribution errors
+		case errors.Is(cerr, cascade.ErrBlobUnknown):
+			code = http.StatusNotFound
+		case errors.Is(cerr, cascade.ErrBlobUploadInvalid):
+			code = http.StatusBadRequest
+		case errors.Is(cerr, cascade.ErrBlobUploadUnknown):
+			code = http.StatusNotFound
+		case errors.Is(cerr, cascade.ErrDigestInvalid):
+			code = http.StatusBadRequest
+		case errors.Is(cerr, cascade.ErrManifestBlobUnknown):
+			code = http.StatusNotFound
+		case errors.Is(cerr, cascade.ErrManifestInvalid):
+			code = http.StatusBadRequest
+		case errors.Is(cerr, cascade.ErrManifestUnknown):
+			code = http.StatusNotFound
+		case errors.Is(cerr, cascade.ErrNameInvalid):
+			code = http.StatusBadRequest
+		case errors.Is(cerr, cascade.ErrNameUnknown):
+			code = http.StatusNotFound
+		case errors.Is(cerr, cascade.ErrSizeInvalid):
+			code = http.StatusBadRequest
+		case errors.Is(cerr, cascade.ErrUnauthorized):
+			code = http.StatusUnauthorized
+		case errors.Is(cerr, cascade.ErrDenied):
+			code = http.StatusForbidden
+		case errors.Is(cerr, cascade.ErrUnsupported):
+			code = http.StatusNotFound
+		case errors.Is(cerr, cascade.ErrTooManyRequests):
+			code = http.StatusTooManyRequests
+		// Extra errors
+		case errors.Is(cerr, cascade.ErrTagInvalid):
+			code = http.StatusBadRequest
+		case errors.Is(cerr, cascade.ErrUploadOffsetInvalid):
+			code = http.StatusRequestedRangeNotSatisfiable
+		}
+
+		response = NewErrorResponse(cerr)
 	}
 
 	w.WriteHeader(code)
-	encodeOrLog(json.NewEncoder(w).Encode(response))
+	if r.Method != http.MethodHead {
+		encodeOrLog(json.NewEncoder(w).Encode(response))
+	}
 }
 
 func NewErrorResponse(err ...cascade.Error) *ErrorResponse {

--- a/server/tags.go
+++ b/server/tags.go
@@ -30,7 +30,11 @@ func (s *Server) listTagsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	tags, _ := s.service.ListTags(repository, count, last)
+	tags, err := s.service.ListTags(repository, count, last)
+	if err != nil {
+		errorHandler(w, r, err)
+		return
+	}
 
 	response := TagsListResponse{
 		Name: repository,

--- a/server/upload_sessions.go
+++ b/server/upload_sessions.go
@@ -14,7 +14,12 @@ func (s *Server) blobsUploadsSessionHandler(w http.ResponseWriter, r *http.Reque
 func (s *Server) initUploadHandler(w http.ResponseWriter, r *http.Request) {
 	repository := r.PathValue("repository")
 
-	session := s.service.InitUpload(repository)
+	session, err := s.service.InitUpload(repository)
+	if err != nil {
+		errorHandler(w, r, err)
+		return
+	}
+
 	w.Header().Set(HeaderLocation, session.Location)
 	w.WriteHeader(http.StatusAccepted)
 }

--- a/server/upload_sessions_test.go
+++ b/server/upload_sessions_test.go
@@ -20,7 +20,7 @@ func TestBlobUploadSession(t *testing.T) {
 		service := mock.NewRegistryService(t)
 		service.EXPECT().
 			InitUpload(name).
-			Return(&cascade.UploadSession{Location: "123"})
+			Return(&cascade.UploadSession{Location: "123"}, nil)
 
 		client := NewTestClientWithServer(t, service)
 

--- a/service.go
+++ b/service.go
@@ -26,7 +26,7 @@ type (
 
 		ListReferrers(repository, digest string, opts *ListReferrersOptions) (*Referrers, error)
 
-		InitUpload(repository string) *UploadSession
+		InitUpload(repository string) (*UploadSession, error)
 		StatUpload(repository, sessionID string) (*FileInfo, error)
 		AppendUpload(repository, sessionID string, r io.Reader, offset int64) error
 		CloseUpload(repository, id, digest string) error

--- a/testing/mock/registry_service.go
+++ b/testing/mock/registry_service.go
@@ -447,7 +447,7 @@ func (_c *RegistryService_GetTag_Call) RunAndReturn(run func(string, string) (st
 }
 
 // InitUpload provides a mock function with given fields: repository
-func (_m *RegistryService) InitUpload(repository string) *cascade.UploadSession {
+func (_m *RegistryService) InitUpload(repository string) (*cascade.UploadSession, error) {
 	ret := _m.Called(repository)
 
 	if len(ret) == 0 {
@@ -455,6 +455,10 @@ func (_m *RegistryService) InitUpload(repository string) *cascade.UploadSession 
 	}
 
 	var r0 *cascade.UploadSession
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (*cascade.UploadSession, error)); ok {
+		return rf(repository)
+	}
 	if rf, ok := ret.Get(0).(func(string) *cascade.UploadSession); ok {
 		r0 = rf(repository)
 	} else {
@@ -463,7 +467,13 @@ func (_m *RegistryService) InitUpload(repository string) *cascade.UploadSession 
 		}
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(repository)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // RegistryService_InitUpload_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'InitUpload'
@@ -484,12 +494,12 @@ func (_c *RegistryService_InitUpload_Call) Run(run func(repository string)) *Reg
 	return _c
 }
 
-func (_c *RegistryService_InitUpload_Call) Return(_a0 *cascade.UploadSession) *RegistryService_InitUpload_Call {
-	_c.Call.Return(_a0)
+func (_c *RegistryService_InitUpload_Call) Return(_a0 *cascade.UploadSession, _a1 error) *RegistryService_InitUpload_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *RegistryService_InitUpload_Call) RunAndReturn(run func(string) *cascade.UploadSession) *RegistryService_InitUpload_Call {
+func (_c *RegistryService_InitUpload_Call) RunAndReturn(run func(string) (*cascade.UploadSession, error)) *RegistryService_InitUpload_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/uploads.go
+++ b/uploads.go
@@ -30,7 +30,7 @@ func (s *registryService) StatUpload(repository, sessionID string) (*FileInfo, e
 
 // TODO: This should be able to return errors, and verify that upload sessions
 // cannot be overwritten _just in case_ the generated UUID is not unique... lol.
-func (s *registryService) InitUpload(repository string) *UploadSession {
+func (s *registryService) InitUpload(repository string) (*UploadSession, error) {
 	id, _ := uuid.NewV7()
 
 	hash := sha256.New()
@@ -58,15 +58,15 @@ func (s *registryService) InitUpload(repository string) *UploadSession {
 
 	err = s.blobs.InitUpload(id)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	err = s.metadata.PutUploadSession(repository, &session)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return &session
+	return &session, nil
 }
 
 func (s *registryService) AppendUpload(repository, sessionID string, r io.Reader, offset int64) error {

--- a/uploads_test.go
+++ b/uploads_test.go
@@ -16,8 +16,9 @@ func TestStatUpload(t *testing.T) {
 		repository := "a/v/c"
 		content := RandomContents(32)
 
-		session := service.InitUpload(repository)
-		err := service.AppendUpload(repository, session.ID.String(), bytes.NewBuffer(content), 0)
+		session, err := service.InitUpload(repository)
+		RequireNoError(t, err)
+		err = service.AppendUpload(repository, session.ID.String(), bytes.NewBuffer(content), 0)
 		RequireNoError(t, err)
 
 		info, err := service.StatUpload(repository, session.ID.String())
@@ -46,9 +47,10 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 		name := RandomName()
 		digest, content := RandomBlob(32)
 
-		session := service.InitUpload(name)
+		session, err := service.InitUpload(name)
+		RequireNoError(t, err)
 
-		err := service.AppendUpload(name, session.ID.String(), bytes.NewBuffer(content), 0)
+		err = service.AppendUpload(name, session.ID.String(), bytes.NewBuffer(content), 0)
 		AssertNoError(t, err)
 
 		err = service.CloseUpload(name, session.ID.String(), digest.String())
@@ -71,9 +73,10 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 		content := RandomContents(32)
 		digest := "blablabla"
 
-		session := service.InitUpload(name)
+		session, err := service.InitUpload(name)
+		RequireNoError(t, err)
 
-		err := service.AppendUpload(name, session.ID.String(), bytes.NewBuffer(content[0:16]), 0)
+		err = service.AppendUpload(name, session.ID.String(), bytes.NewBuffer(content[0:16]), 0)
 		RequireNoError(t, err)
 
 		err = service.CloseUpload(name, session.ID.String(), digest)
@@ -85,9 +88,10 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 		digest := RandomDigest()
 		otherContent := RandomContents(32)
 
-		session := service.InitUpload(name)
+		session, err := service.InitUpload(name)
+		RequireNoError(t, err)
 
-		err := service.AppendUpload(name, session.ID.String(), bytes.NewBuffer(otherContent), 0)
+		err = service.AppendUpload(name, session.ID.String(), bytes.NewBuffer(otherContent), 0)
 		RequireNoError(t, err)
 
 		err = service.CloseUpload(name, session.ID.String(), digest.String())
@@ -102,9 +106,10 @@ func TestServiceUpload(t *testing.T) {
 		name := RandomName()
 		digest, _, content := RandomManifest()
 
-		session := service.InitUpload(name)
+		session, err := service.InitUpload(name)
+		RequireNoError(t, err)
 
-		err := service.AppendUpload(name, session.ID.String(), bytes.NewBuffer(content), 0)
+		err = service.AppendUpload(name, session.ID.String(), bytes.NewBuffer(content), 0)
 		RequireNoError(t, err)
 
 		err = service.CloseUpload(name, session.ID.String(), digest.String())
@@ -122,9 +127,10 @@ func TestServiceUpload(t *testing.T) {
 		repository := RandomName()
 		content := RandomContents(32)
 
-		session := service.InitUpload(repository)
+		session, err := service.InitUpload(repository)
+		RequireNoError(t, err)
 
-		err := service.AppendUpload(repository, session.ID.String(), bytes.NewBuffer(content[:16]), 0)
+		err = service.AppendUpload(repository, session.ID.String(), bytes.NewBuffer(content[:16]), 0)
 		AssertNoError(t, err)
 
 		err = service.AppendUpload(repository, session.ID.String(), bytes.NewBuffer(content[16:]), 16)


### PR DESCRIPTION
I waffled a bit on error handling in the HTTP server. I saw no better options, besides adopting a whole HTTP framework. I went back to the original approach of having one function that maps domain errors to HTTP status codes, cleaning up the function a bit after reading how `errors.As` works.

Closes #23 