### PR TITLE
Rework the test client to call http.Handler

### DIFF
--- a/server/blob_uploads_test.go
+++ b/server/blob_uploads_test.go
@@ -25,7 +25,7 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 			CloseUpload(name, sessionID, digest.String()).
 			Return(nil)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		location := newLocation(name, sessionID)
 		resp := client.CloseUploadWithContent(location, digest, content, 0)
@@ -43,7 +43,7 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 			CloseUpload(name, sessionID, digest.String()).
 			Return(cascade.ErrBlobUploadUnknown)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		location := newLocation(name, sessionID)
 		resp := client.CloseUpload(location, digest)
@@ -61,7 +61,7 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 		query.Add("digest", digest.String())
 		location.RawQuery = query.Encode()
 
-		client := NewTestClientWithRepository(t, name, mock.NewRepositoryService(t))
+		client := NewTestClientForRepository(t, name, mock.NewRepositoryService(t))
 
 		resp := client.Do(
 			http.MethodPut,
@@ -78,7 +78,7 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 		sessionID, _ := uuid.NewV7()
 		location := newLocation(name, sessionID.String())
 
-		client := NewTestClientWithRepository(t, name, mock.NewRepositoryService(t))
+		client := NewTestClientForRepository(t, name, mock.NewRepositoryService(t))
 
 		resp := client.Do(
 			http.MethodPut,
@@ -100,7 +100,7 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 			CloseUpload(name, sessionID.String(), id).
 			Return(cascade.ErrDigestInvalid)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.CloseUpload(location, digest.Digest(id))
 
@@ -118,7 +118,7 @@ func TestBlobUploadsMonolithic(t *testing.T) {
 			CloseUpload(name, sessionID.String(), id.String()).
 			Return(cascade.ErrBlobUploadInvalid)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.CloseUpload(location, id)
 
@@ -141,10 +141,10 @@ func TestBlobUploadsStreamed(t *testing.T) {
 
 		repository := mock.NewRepositoryService(t)
 		repository.EXPECT().
-			AppendUpload(name, sessionID, mock.AnythingOfType("*http.body"), int64(0)).
+			AppendUpload(name, sessionID, mock.AnythingOfType("io.nopCloserWriterTo"), int64(0)).
 			Return(nil)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		location := newLocation(name, sessionID)
 		resp := client.UploadBlobStream(location, bytes.NewBuffer(content))

--- a/server/blobs_test.go
+++ b/server/blobs_test.go
@@ -99,7 +99,7 @@ func TestDeleteBlob(t *testing.T) {
 
 func TestBlobsOthers(t *testing.T) {
 	t.Run("other methods return 405", func(t *testing.T) {
-		client := NewTestClientForServer(t, server.New(nil))
+		client := NewTestClientForHandler(t, server.New(nil))
 
 		resp := client.Do(http.MethodConnect, "/v2/library/fedora/blobs/123", nil, nil)
 

--- a/server/blobs_test.go
+++ b/server/blobs_test.go
@@ -23,7 +23,7 @@ func TestStatBlob(t *testing.T) {
 			StatBlob(name, digest.String()).
 			Return(&cascade.FileInfo{Size: size}, nil)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.CheckBlob(name, digest)
 
@@ -38,7 +38,7 @@ func TestStatBlob(t *testing.T) {
 			StatBlob(name, digest.String()).
 			Return(nil, cascade.ErrBlobUnknown)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.CheckBlob(name, digest)
 
@@ -56,7 +56,7 @@ func TestGetBlob(t *testing.T) {
 			GetBlob(name, digest.String()).
 			Return(bytes.NewBuffer(content), nil)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.GetBlob(name, digest)
 
@@ -70,7 +70,7 @@ func TestGetBlob(t *testing.T) {
 			GetBlob(name, digest.String()).
 			Return(nil, cascade.ErrBlobUnknown)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.GetBlob(name, digest)
 
@@ -89,7 +89,7 @@ func TestDeleteBlob(t *testing.T) {
 			DeleteBlob(name, digest.String()).
 			Return(nil)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.DeleteBlob(name, digest)
 
@@ -99,7 +99,7 @@ func TestDeleteBlob(t *testing.T) {
 
 func TestBlobsOthers(t *testing.T) {
 	t.Run("other methods return 405", func(t *testing.T) {
-		client := NewTestClientWithServer(t, nil)
+		client := NewTestClientForServer(t, server.New(nil))
 
 		resp := client.Do(http.MethodConnect, "/v2/library/fedora/blobs/123", nil, nil)
 

--- a/server/manifests_test.go
+++ b/server/manifests_test.go
@@ -267,7 +267,7 @@ func TestDeleteManifest(t *testing.T) {
 
 func TestManifestsOthers(t *testing.T) {
 	t.Run("Other methods are not allowed", func(t *testing.T) {
-		client := NewTestClientForServer(t, server.New(nil))
+		client := NewTestClientForHandler(t, server.New(nil))
 
 		resp := client.Do(
 			http.MethodTrace,

--- a/server/manifests_test.go
+++ b/server/manifests_test.go
@@ -25,7 +25,7 @@ func TestStatManifests(t *testing.T) {
 			StatManifest(name, digest.String()).
 			Return(&cascade.FileInfo{Size: int64(length)}, nil)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.CheckManifestByDigest(name, digest)
 
@@ -43,7 +43,7 @@ func TestStatManifests(t *testing.T) {
 			StatManifest(name, digest.String()).
 			Return(&cascade.FileInfo{Size: int64(length)}, nil)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.CheckManifestByTag(name, tag)
 
@@ -58,7 +58,7 @@ func TestStatManifests(t *testing.T) {
 			StatManifest(name, digest.String()).
 			Return(nil, cascade.ErrManifestUnknown)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.CheckManifestByDigest(name, digest)
 
@@ -71,7 +71,7 @@ func TestStatManifests(t *testing.T) {
 			GetTag(name, tag).
 			Return("", cascade.ErrManifestUnknown)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.CheckManifestByTag(name, tag)
 
@@ -93,7 +93,7 @@ func TestGetManifests(t *testing.T) {
 			GetManifest(name, digest.String()).
 			Return(meta, content, nil)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.GetManifestByDigest(name, digest)
 
@@ -111,7 +111,7 @@ func TestGetManifests(t *testing.T) {
 			GetManifest(name, digest.String()).
 			Return(meta, content, nil)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.GetManifestByTag(name, tag)
 
@@ -125,7 +125,7 @@ func TestGetManifests(t *testing.T) {
 			GetManifest(name, digest.String()).
 			Return(nil, nil, cascade.ErrManifestUnknown)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.GetManifestByDigest(name, digest)
 
@@ -145,7 +145,7 @@ func TestPutManifest(t *testing.T) {
 			PutManifest(name, digest.String(), content).
 			Return("", nil)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.PutManifest(name, digest.String(), content)
 
@@ -163,7 +163,7 @@ func TestPutManifest(t *testing.T) {
 			PutManifest(name, digest.String(), content).
 			Return("", nil)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.PutManifest(name, tag, content)
 
@@ -181,7 +181,7 @@ func TestPutManifest(t *testing.T) {
 			PutManifest(name, digest.String(), content).
 			Return(subjectDigest, nil)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.PutManifest(name, digest.String(), content)
 
@@ -197,7 +197,7 @@ func TestPutManifest(t *testing.T) {
 			PutManifest(name, digest.String(), content).
 			Return("", cascade.ErrManifestInvalid)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.PutManifest(name, tag, content)
 
@@ -211,7 +211,7 @@ func TestPutManifest(t *testing.T) {
 			PutManifest(name, digest.String(), content).
 			Return("", errors.New("unknown"))
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.PutManifest(name, digest.String(), content)
 
@@ -230,7 +230,7 @@ func TestDeleteManifest(t *testing.T) {
 			DeleteManifest(name, digest.String()).
 			Return(nil)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.DeleteManifest(name, digest)
 
@@ -243,7 +243,7 @@ func TestDeleteManifest(t *testing.T) {
 			DeleteTag(name, tag).
 			Return(nil)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.DeleteTag(name, tag)
 
@@ -256,7 +256,7 @@ func TestDeleteManifest(t *testing.T) {
 			DeleteManifest(name, digest.String()).
 			Return(cascade.ErrManifestUnknown)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.DeleteManifest(name, digest)
 
@@ -267,7 +267,7 @@ func TestDeleteManifest(t *testing.T) {
 
 func TestManifestsOthers(t *testing.T) {
 	t.Run("Other methods are not allowed", func(t *testing.T) {
-		client := NewTestClientWithServer(t, nil)
+		client := NewTestClientForServer(t, server.New(nil))
 
 		resp := client.Do(
 			http.MethodTrace,

--- a/server/referrers_test.go
+++ b/server/referrers_test.go
@@ -28,7 +28,7 @@ func TestListReferrers(t *testing.T) {
 			ListReferrers(wantName, wantDigest.String(), mock.Anything).
 			Return(&wantReferrers, nil)
 
-		client := NewTestClientWithRepository(t, wantName, repository)
+		client := NewTestClientForRepository(t, wantName, repository)
 
 		resp := client.ListReferrers(wantName, wantDigest, nil)
 
@@ -55,7 +55,7 @@ func TestListReferrers(t *testing.T) {
 			ListReferrers(wantName, wantDigest.String(), &wantOpts).
 			Return(&wantReferrers, nil)
 
-		client := NewTestClientWithRepository(t, wantName, repository)
+		client := NewTestClientForRepository(t, wantName, repository)
 
 		resp := client.ListReferrers(wantName, wantDigest, &ListReferrersOptions{
 			ArtifactType: wantArtifactType,
@@ -77,7 +77,7 @@ func TestListReferrers(t *testing.T) {
 			ListReferrers(wantName, wantDigest, mock.Anything).
 			Return(nil, wantErr)
 
-		client := NewTestClientWithRepository(t, wantName, repository)
+		client := NewTestClientForRepository(t, wantName, repository)
 
 		resp := client.ListReferrers(wantName, digest.Digest(wantDigest), nil)
 
@@ -90,7 +90,7 @@ func TestListReferrers(t *testing.T) {
 			ListReferrers(wantName, wantDigest.String(), mock.Anything).
 			Return(nil, errors.New("unknown"))
 
-		client := NewTestClientWithRepository(t, wantName, repository)
+		client := NewTestClientForRepository(t, wantName, repository)
 
 		resp := client.ListReferrers(wantName, wantDigest, nil)
 

--- a/server/tags_test.go
+++ b/server/tags_test.go
@@ -19,7 +19,7 @@ func TestListTags(t *testing.T) {
 			ListTags(name, -1, "").
 			Return(tags, nil)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.ListTags(name, nil)
 
@@ -38,7 +38,7 @@ func TestListTags(t *testing.T) {
 			ListTags(name, count, last).
 			Return(tags[10:13], nil)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.ListTags(name, &ListTagsOptions{
 			N:    Pointer(count),

--- a/server/upload_sessions_test.go
+++ b/server/upload_sessions_test.go
@@ -22,7 +22,7 @@ func TestBlobUploadSession(t *testing.T) {
 			InitUpload(name).
 			Return(&cascade.UploadSession{Location: "123"}, nil)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.InitUpload(name)
 
@@ -36,7 +36,7 @@ func TestBlobUploadSession(t *testing.T) {
 			StatUpload(name, sessionID.String()).
 			Return(&cascade.FileInfo{}, nil)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.CheckUpload(location)
 
@@ -51,7 +51,7 @@ func TestBlobUploadSession(t *testing.T) {
 			StatUpload(name, sessionID.String()).
 			Return(nil, cascade.ErrBlobUploadUnknown)
 
-		client := NewTestClientWithRepository(t, name, repository)
+		client := NewTestClientForRepository(t, name, repository)
 
 		resp := client.CheckUpload(location)
 

--- a/testing/client.go
+++ b/testing/client.go
@@ -18,48 +18,31 @@ import (
 	"github.com/robinkb/cascade-registry/testing/mock"
 )
 
-// NewTestClient returns an initialized Client for the given base URL.
-// A client should be used in the (sub)test where it is created.
-// The given url should be of the form 'http://ipaddr:port' as returned by httptest.Server.URL.
-func NewTestClient(t *testing.T, url string) *Client {
+// NewTestClientForServer returns a test client for the given handler, likely a registry server.
+func NewTestClientForServer(t *testing.T, handler http.Handler) *Client {
 	return &Client{
-		baseUrl: url,
 		t:       t,
+		handler: handler,
 	}
 }
 
-// NewTestClientWithServer initializes an HTTP test server with the given RegistryService
-// and returns an initialized client. The test server is automatically closed
-// at the end of the test. A client should be used in the (sub)test where it is created.
-func NewTestClientWithServer(t *testing.T, service cascade.RegistryService) *Client {
-	server := server.New(service)
-	ts := httptest.NewServer(server)
-
-	t.Cleanup(func() {
-		ts.Close()
-	})
-
-	return NewTestClient(t, ts.URL)
-}
-
-// NewTestClientWithRepository wraps around NewTestClientWithServer to provide an HTTP test server
-// that only returns the given RepositoryService under the specified name. Attempting to
-// create, read, update, or delete objects in any other repository will panic.
-func NewTestClientWithRepository(t *testing.T, name string, service cascade.RepositoryService) *Client {
+// NewTestClientForRepository wraps around NewTestClientForServer to provide a test client
+// for a registry that only returns the given RepositoryService under the specified name.
+// Attempting to create, read, update, or delete objects in any other repository will panic.
+func NewTestClientForRepository(t *testing.T, name string, service cascade.RepositoryService) *Client {
 	registry := mock.NewRegistryService(t)
 	registry.EXPECT().
 		GetRepository(name).
 		Return(service, nil)
 
-	return NewTestClientWithServer(t, registry)
+	return NewTestClientForServer(t, server.New(registry))
 }
 
 // Client is a simple registry client meant for use in testing.
 // It will automatically fail tests if it encounters an unexpected error.
 // Users should initialize it with NewClient().
 type Client struct {
-	http    http.Client
-	baseUrl string
+	handler http.Handler
 	t       *testing.T
 }
 
@@ -244,19 +227,13 @@ func (c *Client) UploadBlobStream(location *url.URL, content io.Reader) *http.Re
 func (c *Client) Do(method string, path string, headers http.Header, body io.Reader) *http.Response {
 	c.t.Helper()
 
-	url := c.baseUrl + path
-	req, err := http.NewRequest(method, url, body)
-	if err != nil {
-		c.t.Fatalf("failed to build request: %s", err)
-	}
-
+	req := httptest.NewRequest(method, path, body)
 	req.Header = headers
+	resp := httptest.NewRecorder()
 
-	resp, err := c.http.Do(req)
-	if err != nil {
-		c.t.Fatalf("unexpected HTTP error: %s", err)
-	}
-	return resp
+	c.handler.ServeHTTP(resp, req)
+
+	return resp.Result()
 }
 
 func Pointer[K any](val K) *K {

--- a/testing/client.go
+++ b/testing/client.go
@@ -26,7 +26,7 @@ func NewTestClientForHandler(t *testing.T, handler http.Handler) *Client {
 	}
 }
 
-// NewTestClientForRepository wraps around NewTestClientForServer to provide a test client
+// NewTestClientForRepository wraps around NewTestClientForHandler to provide a test client
 // for a registry that only returns the given RepositoryService under the specified name.
 // Attempting to create, read, update, or delete objects in any other repository will panic.
 func NewTestClientForRepository(t *testing.T, name string, service cascade.RepositoryService) *Client {

--- a/testing/client.go
+++ b/testing/client.go
@@ -19,8 +19,8 @@ import (
 )
 
 // NewTestClientForHandler returns a test client for the given handler, likely a registry server.
-func NewTestClientForHandler(t *testing.T, handler http.Handler) *Client {
-	return &Client{
+func NewTestClientForHandler(t *testing.T, handler http.Handler) *client {
+	return &client{
 		t:       t,
 		handler: handler,
 	}
@@ -29,7 +29,7 @@ func NewTestClientForHandler(t *testing.T, handler http.Handler) *Client {
 // NewTestClientForRepository wraps around NewTestClientForHandler to provide a test client
 // for a registry that only returns the given RepositoryService under the specified name.
 // Attempting to create, read, update, or delete objects in any other repository will panic.
-func NewTestClientForRepository(t *testing.T, name string, service cascade.RepositoryService) *Client {
+func NewTestClientForRepository(t *testing.T, name string, service cascade.RepositoryService) *client {
 	registry := mock.NewRegistryService(t)
 	registry.EXPECT().
 		GetRepository(name).
@@ -38,50 +38,50 @@ func NewTestClientForRepository(t *testing.T, name string, service cascade.Repos
 	return NewTestClientForHandler(t, server.New(registry))
 }
 
-// Client is a simple registry client meant for use in testing.
+// client is a simple registry client meant for use in testing.
 // It will automatically fail tests if it encounters an unexpected error.
 // Users should initialize it with NewClient().
-type Client struct {
+type client struct {
 	handler http.Handler
 	t       *testing.T
 }
 
-func (c *Client) CheckBlob(name string, digest digest.Digest) *http.Response {
+func (c *client) CheckBlob(name string, digest digest.Digest) *http.Response {
 	path := fmt.Sprintf("/v2/%s/blobs/%s", name, digest)
 	return c.Do(http.MethodHead, path, nil, nil)
 }
 
-func (c *Client) GetBlob(name string, digest digest.Digest) *http.Response {
+func (c *client) GetBlob(name string, digest digest.Digest) *http.Response {
 	path := fmt.Sprintf("/v2/%s/blobs/%s", name, digest)
 	return c.Do(http.MethodGet, path, nil, nil)
 }
 
-func (c *Client) DeleteBlob(name string, digest digest.Digest) *http.Response {
+func (c *client) DeleteBlob(name string, digest digest.Digest) *http.Response {
 	path := fmt.Sprintf("/v2/%s/blobs/%s", name, digest)
 	return c.Do(http.MethodDelete, path, nil, nil)
 }
 
-func (c *Client) CheckManifestByDigest(name string, digest digest.Digest) *http.Response {
+func (c *client) CheckManifestByDigest(name string, digest digest.Digest) *http.Response {
 	path := fmt.Sprintf("/v2/%s/manifests/%s", name, digest)
 	return c.Do(http.MethodHead, path, nil, nil)
 }
 
-func (c *Client) CheckManifestByTag(name string, tag string) *http.Response {
+func (c *client) CheckManifestByTag(name string, tag string) *http.Response {
 	path := fmt.Sprintf("/v2/%s/manifests/%s", name, tag)
 	return c.Do(http.MethodHead, path, nil, nil)
 }
 
-func (c *Client) GetManifestByDigest(name string, digest digest.Digest) *http.Response {
+func (c *client) GetManifestByDigest(name string, digest digest.Digest) *http.Response {
 	path := fmt.Sprintf("/v2/%s/manifests/%s", name, digest)
 	return c.Do(http.MethodGet, path, nil, nil)
 }
 
-func (c *Client) GetManifestByTag(name string, tag string) *http.Response {
+func (c *client) GetManifestByTag(name string, tag string) *http.Response {
 	path := fmt.Sprintf("/v2/%s/manifests/%s", name, tag)
 	return c.Do(http.MethodGet, path, nil, nil)
 }
 
-func (c *Client) PutManifest(name string, reference string, content []byte) *http.Response {
+func (c *client) PutManifest(name string, reference string, content []byte) *http.Response {
 	path := fmt.Sprintf("/v2/%s/manifests/%s", name, reference)
 
 	var manifest v1.Manifest
@@ -96,7 +96,7 @@ func (c *Client) PutManifest(name string, reference string, content []byte) *htt
 	return c.Do(http.MethodPut, path, headers, bytes.NewBuffer(content))
 }
 
-func (c *Client) DeleteManifest(name string, digest digest.Digest) *http.Response {
+func (c *client) DeleteManifest(name string, digest digest.Digest) *http.Response {
 	path := fmt.Sprintf("/v2/%s/manifests/%s", name, digest)
 	return c.Do(http.MethodDelete, path, nil, nil)
 }
@@ -106,7 +106,7 @@ type ListTagsOptions struct {
 	Last string
 }
 
-func (c *Client) ListTags(name string, opts *ListTagsOptions) *http.Response {
+func (c *client) ListTags(name string, opts *ListTagsOptions) *http.Response {
 	u := url.URL{
 		Path: fmt.Sprintf("/v2/%s/tags/list", name),
 	}
@@ -125,7 +125,7 @@ func (c *Client) ListTags(name string, opts *ListTagsOptions) *http.Response {
 	return c.Do(http.MethodGet, u.RequestURI(), nil, nil)
 }
 
-func (c *Client) DeleteTag(name string, tag string) *http.Response {
+func (c *client) DeleteTag(name string, tag string) *http.Response {
 	path := fmt.Sprintf("/v2/%s/manifests/%s", name, tag)
 	return c.Do(http.MethodDelete, path, nil, nil)
 }
@@ -134,7 +134,7 @@ type ListReferrersOptions struct {
 	ArtifactType string
 }
 
-func (c *Client) ListReferrers(name string, digest digest.Digest, opts *ListReferrersOptions) *http.Response {
+func (c *client) ListReferrers(name string, digest digest.Digest, opts *ListReferrersOptions) *http.Response {
 	u := url.URL{
 		Path: fmt.Sprintf("/v2/%s/referrers/%s", name, digest),
 	}
@@ -149,16 +149,16 @@ func (c *Client) ListReferrers(name string, digest digest.Digest, opts *ListRefe
 	return c.Do(http.MethodGet, u.RequestURI(), nil, nil)
 }
 
-func (c *Client) InitUpload(name string) *http.Response {
+func (c *client) InitUpload(name string) *http.Response {
 	path := fmt.Sprintf("/v2/%s/blobs/uploads/", name)
 	return c.Do(http.MethodPost, path, nil, nil)
 }
 
-func (c *Client) CheckUpload(location *url.URL) *http.Response {
+func (c *client) CheckUpload(location *url.URL) *http.Response {
 	return c.Do(http.MethodGet, location.RequestURI(), nil, nil)
 }
 
-func (c *Client) UploadBlobSinglePOST(name string, digest digest.Digest, content []byte) *http.Response {
+func (c *client) UploadBlobSinglePOST(name string, digest digest.Digest, content []byte) *http.Response {
 	path := fmt.Sprintf("/v2/%s/blobs/uploads/", name)
 
 	url, err := url.Parse(path)
@@ -176,7 +176,7 @@ func (c *Client) UploadBlobSinglePOST(name string, digest digest.Digest, content
 }
 
 // CloseUpload performs a PUT to the upload location to close the upload session.
-func (c *Client) CloseUpload(location *url.URL, digest digest.Digest) *http.Response {
+func (c *client) CloseUpload(location *url.URL, digest digest.Digest) *http.Response {
 	query := location.Query()
 	query.Add("digest", digest.String())
 	location.RawQuery = query.Encode()
@@ -187,7 +187,7 @@ func (c *Client) CloseUpload(location *url.URL, digest digest.Digest) *http.Resp
 // CloseUploadWithContent performs a PUT to the upload location to close the upload session
 // while uploading a final chunk. It is functionally the same as a the PUT request
 // in a monolithic POST then PUT upload.
-func (c *Client) CloseUploadWithContent(location *url.URL, digest digest.Digest, content []byte, written int) *http.Response {
+func (c *client) CloseUploadWithContent(location *url.URL, digest digest.Digest, content []byte, written int) *http.Response {
 	buf := bytes.NewBuffer(content)
 	size := len(content)
 	rnge := fmt.Sprintf("%d-%d", written, written+size-1)
@@ -204,7 +204,7 @@ func (c *Client) CloseUploadWithContent(location *url.URL, digest digest.Digest,
 	return c.Do(http.MethodPut, location.RequestURI(), headers, buf)
 }
 
-func (c *Client) UploadBlobChunk(location *url.URL, chunk []byte, written int) *http.Response {
+func (c *client) UploadBlobChunk(location *url.URL, chunk []byte, written int) *http.Response {
 	buf := bytes.NewBuffer(chunk)
 	size := len(chunk)
 	rnge := fmt.Sprintf("%d-%d", written, written+size-1)
@@ -217,14 +217,14 @@ func (c *Client) UploadBlobChunk(location *url.URL, chunk []byte, written int) *
 	return c.Do(http.MethodPatch, location.RequestURI(), headers, buf)
 }
 
-func (c *Client) UploadBlobStream(location *url.URL, content io.Reader) *http.Response {
+func (c *client) UploadBlobStream(location *url.URL, content io.Reader) *http.Response {
 	headers := make(http.Header)
 	headers.Set("Content-Type", "application/octet-stream")
 
 	return c.Do(http.MethodPatch, location.RequestURI(), headers, content)
 }
 
-func (c *Client) Do(method string, path string, headers http.Header, body io.Reader) *http.Response {
+func (c *client) Do(method string, path string, headers http.Header, body io.Reader) *http.Response {
 	c.t.Helper()
 
 	req := httptest.NewRequest(method, path, body)

--- a/testing/client.go
+++ b/testing/client.go
@@ -18,8 +18,8 @@ import (
 	"github.com/robinkb/cascade-registry/testing/mock"
 )
 
-// NewTestClientForServer returns a test client for the given handler, likely a registry server.
-func NewTestClientForServer(t *testing.T, handler http.Handler) *Client {
+// NewTestClientForHandler returns a test client for the given handler, likely a registry server.
+func NewTestClientForHandler(t *testing.T, handler http.Handler) *Client {
 	return &Client{
 		t:       t,
 		handler: handler,
@@ -35,7 +35,7 @@ func NewTestClientForRepository(t *testing.T, name string, service cascade.Repos
 		GetRepository(name).
 		Return(service, nil)
 
-	return NewTestClientForServer(t, server.New(registry))
+	return NewTestClientForHandler(t, server.New(registry))
 }
 
 // Client is a simple registry client meant for use in testing.

--- a/testing/conformance/content_discovery_test.go
+++ b/testing/conformance/content_discovery_test.go
@@ -33,7 +33,7 @@ func TestContentDiscovery(t *testing.T) {
 		slices.Sort(tags)
 
 		t.Run("Fetching the whole list of tags", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			resp := client.ListTags(repository, nil)
 			// Assuming a repository is found, this request MUST return a 200 OK response code.
@@ -54,7 +54,7 @@ func TestContentDiscovery(t *testing.T) {
 		})
 
 		t.Run("Fetching a subset of tags", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			// In addition to fetching the whole list of tags, a subset of the tags can be fetched by providing the n query parameter.
 			resp := client.ListTags(repository, &ListTagsOptions{
@@ -69,7 +69,7 @@ func TestContentDiscovery(t *testing.T) {
 		})
 
 		t.Run("Fetching more tags than are available", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			// The response to such a request MAY return fewer than <int> results, but only when the total number of tags attached to the repository is less than <int> or a Link header is provided.
 			resp := client.ListTags(repository, &ListTagsOptions{
@@ -83,7 +83,7 @@ func TestContentDiscovery(t *testing.T) {
 		})
 
 		t.Run("Fetching 0 tags must return an empty list", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			resp := client.ListTags(repository, &ListTagsOptions{
 				N: Pointer(0),
@@ -99,7 +99,7 @@ func TestContentDiscovery(t *testing.T) {
 		})
 
 		t.Run("Fetch tags with the 'last' query parameter", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			n := 10
 			lastIndex := 10
@@ -142,7 +142,7 @@ func TestContentDiscovery(t *testing.T) {
 			},
 		}
 
-		client := NewTestClientForServer(t, srv)
+		client := NewTestClientForHandler(t, srv)
 
 		resp := client.PutManifest(repository, subjectDigest.String(), subjectContent)
 		AssertResponseCode(t, resp, http.StatusCreated)
@@ -153,7 +153,7 @@ func TestContentDiscovery(t *testing.T) {
 		}
 
 		t.Run("Fetching the full list of referrers", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			resp := client.ListReferrers(repository, subjectDigest, nil)
 			// Assuming a repository is found, this request MUST return a 200 OK response code.
@@ -170,7 +170,7 @@ func TestContentDiscovery(t *testing.T) {
 		})
 
 		t.Run("Fetching a filtered list of referrers", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			// The registry SHOULD support filtering on artifactType.
 			resp := client.ListReferrers(repository, subjectDigest, &ListReferrersOptions{
@@ -195,7 +195,7 @@ func TestContentDiscovery(t *testing.T) {
 		})
 
 		t.Run("List referrers on existing repository without referrers", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			digest := RandomDigest()
 
@@ -205,7 +205,7 @@ func TestContentDiscovery(t *testing.T) {
 		})
 
 		t.Run("List referrers with an invalid request", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			resp := client.ListReferrers(repository, "12345", nil)
 			// If the request is invalid, such as a <digest> with an invalid syntax, a 400 Bad Request MUST be returned.

--- a/testing/conformance/content_discovery_test.go
+++ b/testing/conformance/content_discovery_test.go
@@ -2,7 +2,6 @@ package conformance
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"slices"
 	"testing"
 
@@ -19,9 +18,6 @@ func TestContentDiscovery(t *testing.T) {
 	service := cascade.NewRegistryService(metadata, blobs)
 	srv := server.New(service)
 
-	ts := httptest.NewServer(srv)
-	defer ts.Close()
-
 	t.Run("Listing Tags", func(t *testing.T) {
 		repository := RandomName()
 		digest := RandomDigest()
@@ -37,7 +33,7 @@ func TestContentDiscovery(t *testing.T) {
 		slices.Sort(tags)
 
 		t.Run("Fetching the whole list of tags", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			resp := client.ListTags(repository, nil)
 			// Assuming a repository is found, this request MUST return a 200 OK response code.
@@ -58,7 +54,7 @@ func TestContentDiscovery(t *testing.T) {
 		})
 
 		t.Run("Fetching a subset of tags", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			// In addition to fetching the whole list of tags, a subset of the tags can be fetched by providing the n query parameter.
 			resp := client.ListTags(repository, &ListTagsOptions{
@@ -73,7 +69,7 @@ func TestContentDiscovery(t *testing.T) {
 		})
 
 		t.Run("Fetching more tags than are available", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			// The response to such a request MAY return fewer than <int> results, but only when the total number of tags attached to the repository is less than <int> or a Link header is provided.
 			resp := client.ListTags(repository, &ListTagsOptions{
@@ -87,7 +83,7 @@ func TestContentDiscovery(t *testing.T) {
 		})
 
 		t.Run("Fetching 0 tags must return an empty list", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			resp := client.ListTags(repository, &ListTagsOptions{
 				N: Pointer(0),
@@ -103,7 +99,7 @@ func TestContentDiscovery(t *testing.T) {
 		})
 
 		t.Run("Fetch tags with the 'last' query parameter", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			n := 10
 			lastIndex := 10
@@ -146,7 +142,7 @@ func TestContentDiscovery(t *testing.T) {
 			},
 		}
 
-		client := NewTestClient(t, ts.URL)
+		client := NewTestClientForServer(t, srv)
 
 		resp := client.PutManifest(repository, subjectDigest.String(), subjectContent)
 		AssertResponseCode(t, resp, http.StatusCreated)
@@ -157,7 +153,7 @@ func TestContentDiscovery(t *testing.T) {
 		}
 
 		t.Run("Fetching the full list of referrers", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			resp := client.ListReferrers(repository, subjectDigest, nil)
 			// Assuming a repository is found, this request MUST return a 200 OK response code.
@@ -174,7 +170,7 @@ func TestContentDiscovery(t *testing.T) {
 		})
 
 		t.Run("Fetching a filtered list of referrers", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			// The registry SHOULD support filtering on artifactType.
 			resp := client.ListReferrers(repository, subjectDigest, &ListReferrersOptions{
@@ -199,7 +195,7 @@ func TestContentDiscovery(t *testing.T) {
 		})
 
 		t.Run("List referrers on existing repository without referrers", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			digest := RandomDigest()
 
@@ -209,7 +205,7 @@ func TestContentDiscovery(t *testing.T) {
 		})
 
 		t.Run("List referrers with an invalid request", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			resp := client.ListReferrers(repository, "12345", nil)
 			// If the request is invalid, such as a <digest> with an invalid syntax, a 400 Bad Request MUST be returned.

--- a/testing/conformance/content_management_test.go
+++ b/testing/conformance/content_management_test.go
@@ -2,7 +2,6 @@ package conformance
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/robinkb/cascade-registry"
@@ -17,15 +16,12 @@ func TestContentManagement(t *testing.T) {
 	service := cascade.NewRegistryService(metadata, blobs)
 	srv := server.New(service)
 
-	ts := httptest.NewServer(srv)
-	defer ts.Close()
-
 	t.Run("Deleting tags", func(t *testing.T) {
 		repository := RandomName()
 		_, _, manifest := RandomManifest()
 		tag := RandomVersion()
 
-		client := NewTestClient(t, ts.URL)
+		client := NewTestClientForServer(t, srv)
 
 		resp := client.PutManifest(repository, tag, manifest)
 		AssertResponseCode(t, resp, http.StatusCreated)
@@ -45,7 +41,7 @@ func TestContentManagement(t *testing.T) {
 		repository := RandomName()
 		digest, _, content := RandomManifest()
 
-		client := NewTestClient(t, ts.URL)
+		client := NewTestClientForServer(t, srv)
 
 		resp := client.PutManifest(repository, digest.String(), content)
 		AssertResponseCode(t, resp, http.StatusCreated)
@@ -71,7 +67,7 @@ func TestContentManagement(t *testing.T) {
 		name := RandomName()
 		digest, content := RandomBlob(64)
 
-		client := NewTestClient(t, ts.URL)
+		client := NewTestClientForServer(t, srv)
 
 		resp := client.InitUpload(name)
 		AssertResponseCode(t, resp, http.StatusAccepted)

--- a/testing/conformance/content_management_test.go
+++ b/testing/conformance/content_management_test.go
@@ -21,7 +21,7 @@ func TestContentManagement(t *testing.T) {
 		_, _, manifest := RandomManifest()
 		tag := RandomVersion()
 
-		client := NewTestClientForServer(t, srv)
+		client := NewTestClientForHandler(t, srv)
 
 		resp := client.PutManifest(repository, tag, manifest)
 		AssertResponseCode(t, resp, http.StatusCreated)
@@ -41,7 +41,7 @@ func TestContentManagement(t *testing.T) {
 		repository := RandomName()
 		digest, _, content := RandomManifest()
 
-		client := NewTestClientForServer(t, srv)
+		client := NewTestClientForHandler(t, srv)
 
 		resp := client.PutManifest(repository, digest.String(), content)
 		AssertResponseCode(t, resp, http.StatusCreated)
@@ -67,7 +67,7 @@ func TestContentManagement(t *testing.T) {
 		name := RandomName()
 		digest, content := RandomBlob(64)
 
-		client := NewTestClientForServer(t, srv)
+		client := NewTestClientForHandler(t, srv)
 
 		resp := client.InitUpload(name)
 		AssertResponseCode(t, resp, http.StatusAccepted)

--- a/testing/conformance/pull_test.go
+++ b/testing/conformance/pull_test.go
@@ -2,7 +2,6 @@ package conformance
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"strconv"
 	"testing"
 
@@ -16,14 +15,11 @@ func TestPull(t *testing.T) {
 	metadata := inmemory.NewMetadataStore()
 	blobs := inmemory.NewBlobStore()
 	service := cascade.NewRegistryService(metadata, blobs)
-	server := server.New(service)
-
-	ts := httptest.NewServer(server)
-	defer ts.Close()
+	srv := server.New(service)
 
 	t.Run("Pulling manifests", func(t *testing.T) {
 		t.Run("GET request to a known manifest", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			name := RandomName()
 			digest, manifest, content := RandomManifest()
@@ -43,7 +39,7 @@ func TestPull(t *testing.T) {
 		})
 
 		t.Run("GET request to an unknown manifest", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			name, digest := RandomName(), RandomDigest()
 			resp := client.GetManifestByDigest(name, digest)
@@ -63,7 +59,8 @@ func TestPull(t *testing.T) {
 		RequireNoError(t, err)
 
 		t.Run("GET request to an existing blob", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
+
 			resp := client.GetBlob(name, digest)
 
 			// A GET request to an existing blob URL MUST provide the expected blob, with a response code that MUST be 200 OK.
@@ -72,7 +69,7 @@ func TestPull(t *testing.T) {
 		})
 
 		t.Run("GET request to an unknown blob", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			name, digest := RandomName(), RandomDigest()
 			resp := client.GetBlob(name, digest)
@@ -84,7 +81,7 @@ func TestPull(t *testing.T) {
 
 	t.Run("Checking if content exists in the registry", func(t *testing.T) {
 		t.Run("HEAD request to an existing blob", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			name := RandomName()
 			digest, blob := RandomBlob(32)
@@ -105,7 +102,7 @@ func TestPull(t *testing.T) {
 		})
 
 		t.Run("HEAD request to an unknown blob", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			name, digest := RandomName(), RandomDigest()
 			resp := client.CheckBlob(name, digest)
@@ -115,7 +112,7 @@ func TestPull(t *testing.T) {
 		})
 
 		t.Run("HEAD request to an existing manifest", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			name := RandomName()
 			digest, _, content := RandomManifest()
@@ -134,7 +131,7 @@ func TestPull(t *testing.T) {
 		})
 
 		t.Run("HEAD request to an unknown manifest", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			name, digest := RandomName(), RandomDigest()
 

--- a/testing/conformance/pull_test.go
+++ b/testing/conformance/pull_test.go
@@ -19,7 +19,7 @@ func TestPull(t *testing.T) {
 
 	t.Run("Pulling manifests", func(t *testing.T) {
 		t.Run("GET request to a known manifest", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			name := RandomName()
 			digest, manifest, content := RandomManifest()
@@ -39,7 +39,7 @@ func TestPull(t *testing.T) {
 		})
 
 		t.Run("GET request to an unknown manifest", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			name, digest := RandomName(), RandomDigest()
 			resp := client.GetManifestByDigest(name, digest)
@@ -59,7 +59,7 @@ func TestPull(t *testing.T) {
 		RequireNoError(t, err)
 
 		t.Run("GET request to an existing blob", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			resp := client.GetBlob(name, digest)
 
@@ -69,7 +69,7 @@ func TestPull(t *testing.T) {
 		})
 
 		t.Run("GET request to an unknown blob", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			name, digest := RandomName(), RandomDigest()
 			resp := client.GetBlob(name, digest)
@@ -81,7 +81,7 @@ func TestPull(t *testing.T) {
 
 	t.Run("Checking if content exists in the registry", func(t *testing.T) {
 		t.Run("HEAD request to an existing blob", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			name := RandomName()
 			digest, blob := RandomBlob(32)
@@ -102,7 +102,7 @@ func TestPull(t *testing.T) {
 		})
 
 		t.Run("HEAD request to an unknown blob", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			name, digest := RandomName(), RandomDigest()
 			resp := client.CheckBlob(name, digest)
@@ -112,7 +112,7 @@ func TestPull(t *testing.T) {
 		})
 
 		t.Run("HEAD request to an existing manifest", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			name := RandomName()
 			digest, _, content := RandomManifest()
@@ -131,7 +131,7 @@ func TestPull(t *testing.T) {
 		})
 
 		t.Run("HEAD request to an unknown manifest", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			name, digest := RandomName(), RandomDigest()
 

--- a/testing/conformance/push_test.go
+++ b/testing/conformance/push_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/robinkb/cascade-registry"
@@ -18,15 +17,12 @@ func TestPush(t *testing.T) {
 	metadata := inmemory.NewMetadataStore()
 	blobs := inmemory.NewBlobStore()
 	service := cascade.NewRegistryService(metadata, blobs)
-	server := server.New(service)
-
-	ts := httptest.NewServer(server)
-	defer ts.Close()
+	srv := server.New(service)
 
 	t.Run("Pushing blobs", func(t *testing.T) {
 		t.Run("Pushing a blob monolithically", func(t *testing.T) {
 			t.Run("POST then PUT", func(t *testing.T) {
-				client := NewTestClient(t, ts.URL)
+				client := NewTestClientForServer(t, srv)
 
 				name := RandomName()
 				digest, blob := RandomBlob(32)
@@ -53,7 +49,7 @@ func TestPush(t *testing.T) {
 			})
 
 			t.Run("Single POST", func(t *testing.T) {
-				client := NewTestClient(t, ts.URL)
+				client := NewTestClientForServer(t, srv)
 
 				// Registries MAY support pushing blobs using a single POST request.
 				// Cascade does not.
@@ -70,7 +66,7 @@ func TestPush(t *testing.T) {
 		})
 
 		t.Run("Pushing a blob in chunks", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			name := RandomName()
 			digest, blob := RandomBlob(64 * 1024)
@@ -145,7 +141,7 @@ func TestPush(t *testing.T) {
 
 		// This is not part of the spec (yet).
 		t.Run("Pushing a blob as a stream", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			name := RandomName()
 			digest, blob := RandomBlob(64 * 1024)
@@ -171,7 +167,7 @@ func TestPush(t *testing.T) {
 
 	t.Run("Pushing manifests", func(t *testing.T) {
 		t.Run("Pushing manifest by digest", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			name := RandomName()
 			digest, _, content := RandomManifest()
@@ -190,7 +186,7 @@ func TestPush(t *testing.T) {
 		})
 
 		t.Run("Pushing manifest by tag", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			name := RandomName()
 			digest, _, content := RandomManifest()
@@ -216,7 +212,7 @@ func TestPush(t *testing.T) {
 		t.Run("Pushing manifest with layers", func(t *testing.T) {})
 
 		t.Run("Pushing manifests with Subject", func(t *testing.T) {
-			client := NewTestClient(t, ts.URL)
+			client := NewTestClientForServer(t, srv)
 
 			name := RandomName()
 			subjectDigest, subjectManifest, _ := RandomManifest()

--- a/testing/conformance/push_test.go
+++ b/testing/conformance/push_test.go
@@ -22,7 +22,7 @@ func TestPush(t *testing.T) {
 	t.Run("Pushing blobs", func(t *testing.T) {
 		t.Run("Pushing a blob monolithically", func(t *testing.T) {
 			t.Run("POST then PUT", func(t *testing.T) {
-				client := NewTestClientForServer(t, srv)
+				client := NewTestClientForHandler(t, srv)
 
 				name := RandomName()
 				digest, blob := RandomBlob(32)
@@ -49,7 +49,7 @@ func TestPush(t *testing.T) {
 			})
 
 			t.Run("Single POST", func(t *testing.T) {
-				client := NewTestClientForServer(t, srv)
+				client := NewTestClientForHandler(t, srv)
 
 				// Registries MAY support pushing blobs using a single POST request.
 				// Cascade does not.
@@ -66,7 +66,7 @@ func TestPush(t *testing.T) {
 		})
 
 		t.Run("Pushing a blob in chunks", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			name := RandomName()
 			digest, blob := RandomBlob(64 * 1024)
@@ -141,7 +141,7 @@ func TestPush(t *testing.T) {
 
 		// This is not part of the spec (yet).
 		t.Run("Pushing a blob as a stream", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			name := RandomName()
 			digest, blob := RandomBlob(64 * 1024)
@@ -167,7 +167,7 @@ func TestPush(t *testing.T) {
 
 	t.Run("Pushing manifests", func(t *testing.T) {
 		t.Run("Pushing manifest by digest", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			name := RandomName()
 			digest, _, content := RandomManifest()
@@ -186,7 +186,7 @@ func TestPush(t *testing.T) {
 		})
 
 		t.Run("Pushing manifest by tag", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			name := RandomName()
 			digest, _, content := RandomManifest()
@@ -212,7 +212,7 @@ func TestPush(t *testing.T) {
 		t.Run("Pushing manifest with layers", func(t *testing.T) {})
 
 		t.Run("Pushing manifests with Subject", func(t *testing.T) {
-			client := NewTestClientForServer(t, srv)
+			client := NewTestClientForHandler(t, srv)
 
 			name := RandomName()
 			subjectDigest, subjectManifest, _ := RandomManifest()


### PR DESCRIPTION
Removes the need for starting up an actual test server. While starting up a real HTTP server is neat, it's slower. Tests that previous started up an HTTP server run about 3x faster now.