### PR TITLE
Add toggles for package repository tests

### DIFF
--- a/repository/blobs_test.go
+++ b/repository/blobs_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (s *Suite) TestStatBlob() {
+	if s.Tests.BlobsDisabled {
+		s.T().SkipNow()
+	}
+
 	name := RandomName()
 	digest, content := RandomBlob(32 * 1024)
 
@@ -34,6 +38,10 @@ func (s *Suite) TestStatBlob() {
 }
 
 func (s *Suite) TestGetBlob() {
+	if s.Tests.BlobsDisabled {
+		s.T().SkipNow()
+	}
+
 	name := RandomName()
 	digest, content := RandomBlob(32)
 
@@ -62,6 +70,10 @@ func (s *Suite) TestGetBlob() {
 }
 
 func (s *Suite) TestDeleteBlob() {
+	if s.Tests.BlobsDisabled {
+		s.T().SkipNow()
+	}
+
 	name := RandomName()
 	digest, content := RandomBlob(32)
 

--- a/repository/manifests_test.go
+++ b/repository/manifests_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (s *Suite) TestStatManifest() {
+	if s.Tests.ManifestsDisbabled {
+		s.T().SkipNow()
+	}
+
 	name := RandomName()
 	digest, _, content := RandomManifest()
 
@@ -47,6 +51,10 @@ func (s *Suite) TestStatManifest() {
 }
 
 func (s *Suite) TestGetManifest() {
+	if s.Tests.ManifestsDisbabled {
+		s.T().SkipNow()
+	}
+
 	name := RandomName()
 	digest, _, content := RandomManifest()
 
@@ -90,6 +98,10 @@ func (s *Suite) TestGetManifest() {
 }
 
 func (s *Suite) TestPutManifest() {
+	if s.Tests.ManifestsDisbabled {
+		s.T().SkipNow()
+	}
+
 	name := RandomName()
 
 	s.T().Run("Put and retrieve a manifest", func(t *testing.T) {
@@ -134,6 +146,10 @@ func (s *Suite) TestPutManifest() {
 }
 
 func (s *Suite) TestDeleteManifest() {
+	if s.Tests.ManifestsDisbabled {
+		s.T().SkipNow()
+	}
+
 	s.T().Run("Delete manifest and make sure it cannot be retrieved", func(t *testing.T) {
 		name := RandomName()
 		digest, _, content := RandomManifest()

--- a/repository/service_test.go
+++ b/repository/service_test.go
@@ -23,12 +23,15 @@ type Suite struct {
 	blobs      store.Blobs
 }
 
+// Tests allows selectively disabling tests in the suite. Useful when developing new store backends.
+// The Tests struct roughly lists the tests in order of easiest to hardest, so it is recommend
+// to make the tests pass in that order.
 type Tests struct {
 	BlobsDisabled      bool
 	ManifestsDisbabled bool
-	ReferrersDisabled  bool
 	TagsDisabled       bool
 	UploadsDisabled    bool
+	ReferrersDisabled  bool
 }
 
 func (s *Suite) SetupSuite() {

--- a/repository/service_test.go
+++ b/repository/service_test.go
@@ -16,10 +16,19 @@ type Suite struct {
 	suite.Suite
 
 	StoreConstructor StoreConstructor
+	Tests            Tests
 
 	repository repository.RepositoryService
 	metadata   store.Metadata
 	blobs      store.Blobs
+}
+
+type Tests struct {
+	BlobsDisabled      bool
+	ManifestsDisbabled bool
+	ReferrersDisabled  bool
+	TagsDisabled       bool
+	UploadsDisabled    bool
 }
 
 func (s *Suite) SetupSuite() {

--- a/repository/tags_test.go
+++ b/repository/tags_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (s *Suite) TestGetTag() {
+	if s.Tests.TagsDisabled {
+		s.T().SkipNow()
+	}
+
 	name := RandomName()
 
 	s.T().Run("Manifest digest is retrievable by tag", func(t *testing.T) {
@@ -33,6 +37,10 @@ func (s *Suite) TestGetTag() {
 }
 
 func (s *Suite) TestPutTag() {
+	if s.Tests.TagsDisabled {
+		s.T().SkipNow()
+	}
+
 	name := RandomName()
 
 	s.T().Run("Tag creates a link to the manifest digest", func(t *testing.T) {
@@ -56,6 +64,10 @@ func (s *Suite) TestPutTag() {
 }
 
 func (s *Suite) TestDeleteTag() {
+	if s.Tests.TagsDisabled {
+		s.T().SkipNow()
+	}
+
 	name := RandomName()
 
 	s.T().Run("Deleted tag is not retrievable", func(t *testing.T) {
@@ -77,6 +89,10 @@ func (s *Suite) TestDeleteTag() {
 }
 
 func (s *Suite) TestListTag() {
+	if s.Tests.TagsDisabled {
+		s.T().SkipNow()
+	}
+
 	s.T().Run("Listing tags returns all in lexical order", func(t *testing.T) {
 		name := RandomName()
 		digest := RandomDigest()

--- a/repository/uploads_test.go
+++ b/repository/uploads_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func (s *Suite) TestStatUpload() {
+	if s.Tests.UploadsDisabled {
+		s.T().SkipNow()
+	}
+
 	s.T().Run("stat upload returns correct FileInfo", func(t *testing.T) {
 		name := RandomName()
 		content := RandomContents(32)
@@ -39,6 +43,10 @@ func (s *Suite) TestStatUpload() {
 }
 
 func (s *Suite) TestBlobUploadsMonolithic() {
+	if s.Tests.UploadsDisabled {
+		s.T().SkipNow()
+	}
+
 	name := RandomName()
 
 	s.T().Run("Monolithic blob upload - happy path", func(t *testing.T) {
@@ -95,6 +103,10 @@ func (s *Suite) TestBlobUploadsMonolithic() {
 }
 
 func (s *Suite) TestServiceUpload() {
+	if s.Tests.UploadsDisabled {
+		s.T().SkipNow()
+	}
+
 	name := RandomName()
 
 	s.T().Run("written upload is retrievable", func(t *testing.T) {


### PR DESCRIPTION
Allows selectively disabling tests in the suite. Useful when developing new store backends. The Tests struct roughly lists the tests in order of easiest to hardest, so it is recommend to make the tests pass in that order.