### PR TITLE
Generalize Raft node functionality

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1,20 +1,25 @@
 package cluster
 
-import "github.com/robinkb/cascade-registry/store"
-
 type (
 	// Controller manages Nodes.
 	Controller struct{}
 
 	// Node represents a clustered node.
 	Node interface {
-		store.Metadata
-
 		Start()
 		ClusterStatus() Status
+		Propose(op Operation) error
+		// Consumers must call Process() to register a function that processes operations.
+		Process(op Operation, f ProcessFunc)
 	}
+
+	ProcessFunc func(op Operation) error
 
 	Status struct {
 		Clustered bool
+	}
+
+	Operation interface {
+		ID() uint64
 	}
 )

--- a/cluster/raft/raft.go
+++ b/cluster/raft/raft.go
@@ -7,14 +7,12 @@ import (
 	"io"
 	"log"
 	"math"
-	"math/rand/v2"
 	"net"
+	"reflect"
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/opencontainers/go-digest"
 	"github.com/robinkb/cascade-registry/cluster"
-	"github.com/robinkb/cascade-registry/store"
 	"go.etcd.io/raft/v3"
 	"go.etcd.io/raft/v3/raftpb"
 )
@@ -28,7 +26,7 @@ type Peer struct {
 	Addr net.TCPAddr
 }
 
-func NewRaftNode(id uint64, addr *net.TCPAddr, peers []Peer, metadata store.Metadata) cluster.Node {
+func NewNode(id uint64, addr *net.TCPAddr, peers []Peer) cluster.Node {
 	storage := raft.NewMemoryStorage()
 	conf := raft.Config{
 		ID:              id,
@@ -55,7 +53,7 @@ func NewRaftNode(id uint64, addr *net.TCPAddr, peers []Peer, metadata store.Meta
 		addr:  addr,
 		peers: npeers,
 
-		Metadata: metadata,
+		processFuncs: make(map[reflect.Type]cluster.ProcessFunc),
 	}
 
 	nodes[id] = node
@@ -73,7 +71,7 @@ type node struct {
 	peers map[uint64]Peer
 	addr  *net.TCPAddr
 
-	store.Metadata
+	processFuncs map[reflect.Type]cluster.ProcessFunc
 }
 
 func (n *node) Start() {
@@ -219,93 +217,26 @@ func (n *node) saveToStorage(hardState raftpb.HardState, entries []raftpb.Entry,
 	}
 }
 
-func (n *node) CreateRepository(name string) error {
-	op := &createRepository{
-		rand.Uint64(),
-		name,
-	}
+func (n *node) Propose(op cluster.Operation) error {
 	return n.propose(op)
 }
 
-func (n *node) DeleteRepository(name string) error {
-	op := &deleteRepository{
-		rand.Uint64(),
-		name,
+func (n *node) Process(op cluster.Operation, f cluster.ProcessFunc) {
+	t := reflect.TypeOf(op)
+	if _, ok := n.processFuncs[t]; ok {
+		log.Fatalf("operation already registered: %T", op)
 	}
-	return n.propose(op)
+	n.processFuncs[reflect.TypeOf(op)] = f
+	gob.Register(op)
 }
 
-func (n *node) PutBlob(name string, digest digest.Digest) error {
-	op := &putBlob{
-		rand.Uint64(),
-		name, digest,
-	}
-	return n.propose(op)
-}
-
-func (n *node) DeleteBlob(name string, digest digest.Digest) error {
-	op := &deleteBlob{
-		rand.Uint64(),
-		name, digest,
-	}
-	return n.propose(op)
-}
-
-func (n *node) PutManifest(name string, digest digest.Digest, meta *store.ManifestMetadata) error {
-	op := &putManifest{
-		rand.Uint64(),
-		name, digest, meta,
-	}
-	return n.propose(op)
-}
-
-func (n *node) DeleteManifest(name string, digest digest.Digest) error {
-	op := &deleteManifest{
-		rand.Uint64(),
-		name, digest,
-	}
-	return n.propose(op)
-}
-
-func (n *node) PutTag(name, tag string, digest digest.Digest) error {
-	op := &putTag{
-		rand.Uint64(),
-		name, tag, digest,
-	}
-	return n.propose(op)
-}
-
-func (n *node) DeleteTag(name, tag string) error {
-	op := &deleteTag{
-		rand.Uint64(),
-		name, tag,
-	}
-	return n.propose(op)
-}
-
-func (n *node) PutUploadSession(name string, session *store.UploadSession) error {
-	op := &putUploadSession{
-		rand.Uint64(),
-		name, session,
-	}
-	return n.propose(op)
-}
-
-func (n *node) DeleteUploadSession(name string, id string) error {
-	op := &deleteUploadSession{
-		rand.Uint64(),
-		name, id,
-	}
-	return n.propose(op)
-}
-
-func (n *node) propose(o operation) error {
+func (n *node) propose(op cluster.Operation) error {
 	var buf bytes.Buffer
-	if err := gob.NewEncoder(&buf).Encode(&o); err != nil {
+	if err := gob.NewEncoder(&buf).Encode(&op); err != nil {
 		log.Panicf("failed to encode operation: %s\n", err)
 	}
 
-	n.errors[o.ID()] = make(chan error)
+	n.errors[op.ID()] = make(chan error)
 	// Propose blocks until accepted by the cluster.
 	// TODO: Find out how to retry proposals.
 	err := n.raft.Propose(context.TODO(), buf.Bytes())
@@ -316,7 +247,7 @@ func (n *node) propose(o operation) error {
 	select {
 	case <-time.Tick(5 * time.Second):
 		panic("timed out")
-	case <-n.errors[o.ID()]:
+	case <-n.errors[op.ID()]:
 		return err
 	}
 }
@@ -325,44 +256,25 @@ func (n *node) process(entry raftpb.Entry) {
 	if entry.Data != nil {
 		buf := bytes.NewBuffer(entry.Data)
 
-		var c operation
-		err := gob.NewDecoder(buf).Decode(&c)
+		var op cluster.Operation
+		err := gob.NewDecoder(buf).Decode(&op)
 		if err != nil {
 			log.Panicf("unable to decode as operation: %s", err)
 		}
 
-		switch v := c.(type) {
-		case *createRepository:
-			err = n.Metadata.CreateRepository(v.Name)
-		case *deleteRepository:
-			err = n.Metadata.DeleteRepository(v.Name)
-		case *putBlob:
-			err = n.Metadata.PutBlob(v.Name, v.Digest)
-		case *deleteBlob:
-			err = n.Metadata.DeleteBlob(v.Name, v.Digest)
-		case *putManifest:
-			err = n.Metadata.PutManifest(v.Name, v.Digest, v.Meta)
-		case *deleteManifest:
-			err = n.Metadata.DeleteManifest(v.Name, v.Digest)
-		case *putTag:
-			err = n.Metadata.PutTag(v.Name, v.Tag, v.Digest)
-		case *deleteTag:
-			err = n.Metadata.DeleteTag(v.Name, v.Tag)
-		case *putUploadSession:
-			err = n.Metadata.PutUploadSession(v.Name, v.Session)
-		case *deleteUploadSession:
-			err = n.Metadata.DeleteUploadSession(v.Name, v.SessionID)
-		default:
-			log.Panicf("unknown operation received: %T", v)
+		f, ok := n.processFuncs[reflect.TypeOf(op)]
+		if !ok {
+			log.Panicf("unknown operation received: %T", op)
 		}
+		err = f(op)
 
-		errC, ok := n.errors[c.ID()]
+		errC, ok := n.errors[op.ID()]
 		if ok {
 			if err != nil {
 				errC <- err
 			} else {
 				close(errC)
-				delete(n.errors, c.ID())
+				delete(n.errors, op.ID())
 			}
 		}
 	}

--- a/cluster/raft/raft_test.go
+++ b/cluster/raft/raft_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gofrs/uuid/v5"
 	"github.com/robinkb/cascade-registry/cluster"
 	"github.com/robinkb/cascade-registry/store"
+	storecluster "github.com/robinkb/cascade-registry/store/cluster"
 	"github.com/robinkb/cascade-registry/store/inmemory"
 	. "github.com/robinkb/cascade-registry/testing"
 )
@@ -17,10 +18,12 @@ var (
 	localhost = net.ParseIP("127.0.0.1")
 )
 
-func newTestCluster(n int) []cluster.Node {
-	nodes := make([]cluster.Node, n)
+func newTestCluster(n int) ([]cluster.Node, []store.Metadata) {
 	peers := make([]Peer, n)
-	for i := range peers {
+	nodes := make([]cluster.Node, n)
+	metadata := make([]store.Metadata, n)
+
+	for i := range n {
 		peers[i] = Peer{
 			ID: rand.Uint64(),
 			Addr: net.TCPAddr{
@@ -30,16 +33,16 @@ func newTestCluster(n int) []cluster.Node {
 		}
 	}
 
-	for i := range nodes {
-		nodes[i] = NewRaftNode(
+	for i := range n {
+		nodes[i] = NewNode(
 			peers[i].ID,
 			&peers[i].Addr,
 			peers,
-			inmemory.NewMetadataStore(),
 		)
+		metadata[i] = storecluster.NewMetadataStore(nodes[i], inmemory.NewMetadataStore())
 	}
 
-	return nodes
+	return nodes, metadata
 }
 
 func randomPort() int {
@@ -47,7 +50,7 @@ func randomPort() int {
 }
 
 func TestRaftClusterFormation(t *testing.T) {
-	nodes := newTestCluster(3)
+	nodes, _ := newTestCluster(3)
 
 	for _, n := range nodes {
 		AssertEqual(t, n.ClusterStatus().Clustered, false)
@@ -63,7 +66,7 @@ func TestRaftClusterFormation(t *testing.T) {
 
 func TestRaftClusterReplication(t *testing.T) {
 	t.Parallel()
-	nodes := newTestCluster(3)
+	nodes, metadata := newTestCluster(3)
 	for _, n := range nodes {
 		n.Start()
 	}
@@ -73,55 +76,55 @@ func TestRaftClusterReplication(t *testing.T) {
 
 	t.Run("Ensure repository metadata is replicated", func(t *testing.T) {
 		name := RandomName()
-		err := nodes[0].CreateRepository(name)
+		err := metadata[0].CreateRepository(name)
 		AssertNoError(t, err)
 
 		time.Sleep(1 * time.Millisecond)
 
-		for _, n := range nodes {
-			err := n.GetRepository(name)
+		for _, m := range metadata {
+			err := m.GetRepository(name)
 			AssertNoError(t, err)
 		}
 
-		err = nodes[0].DeleteRepository(name)
+		err = metadata[0].DeleteRepository(name)
 		AssertNoError(t, err)
 
 		time.Sleep(1 * time.Millisecond)
 
-		for _, n := range nodes {
-			err := n.GetRepository(name)
+		for _, m := range metadata {
+			err := m.GetRepository(name)
 			AssertErrorIs(t, err, store.ErrRepositoryNotFound)
 		}
 	})
 
 	t.Run("Ensure blob metadata is replicated", func(t *testing.T) {
 		name, digest := RandomName(), RandomDigest()
-		err := nodes[0].CreateRepository(name)
+		err := metadata[0].CreateRepository(name)
 		RequireNoError(t, err)
-		err = nodes[0].PutBlob(name, digest)
+		err = metadata[0].PutBlob(name, digest)
 		AssertNoError(t, err)
 
 		time.Sleep(1 * time.Millisecond)
 
-		for _, n := range nodes {
-			_, err := n.GetBlob(name, digest)
+		for _, m := range metadata {
+			_, err := m.GetBlob(name, digest)
 			AssertNoError(t, err)
 		}
 
-		err = nodes[0].DeleteBlob(name, digest)
+		err = metadata[0].DeleteBlob(name, digest)
 		AssertNoError(t, err)
 
 		time.Sleep(1 * time.Millisecond)
 
-		for _, n := range nodes {
-			_, err := n.GetBlob(name, digest)
+		for _, m := range metadata {
+			_, err := m.GetBlob(name, digest)
 			AssertErrorIs(t, err, store.ErrNotFound)
 		}
 	})
 
 	t.Run("Ensure manifest metadata is replicated", func(t *testing.T) {
 		name := RandomName()
-		err := nodes[0].CreateRepository(name)
+		err := metadata[0].CreateRepository(name)
 		RequireNoError(t, err)
 
 		digest, manifest, content := RandomManifest()
@@ -131,81 +134,81 @@ func TestRaftClusterReplication(t *testing.T) {
 			MediaType:    manifest.MediaType,
 			Size:         int64(len(content)),
 		}
-		err = nodes[0].PutManifest(name, digest, meta)
+		err = metadata[0].PutManifest(name, digest, meta)
 		AssertNoError(t, err)
 
 		time.Sleep(1 * time.Millisecond)
 
-		for _, n := range nodes {
-			got, err := n.GetManifest(name, digest)
+		for _, s := range metadata {
+			got, err := s.GetManifest(name, digest)
 			AssertNoError(t, err)
 			AssertStructsEqual(t, got, meta)
 		}
 
-		err = nodes[0].DeleteManifest(name, digest)
+		err = metadata[0].DeleteManifest(name, digest)
 		AssertNoError(t, err)
 
 		time.Sleep(1 * time.Millisecond)
 
-		for _, n := range nodes {
-			_, err := n.GetManifest(name, digest)
+		for _, s := range metadata {
+			_, err := s.GetManifest(name, digest)
 			AssertErrorIs(t, err, store.ErrMetadataNotFound)
 		}
 	})
 
 	t.Run("Ensure tag metadata is replicated", func(t *testing.T) {
 		name, tag, digest := RandomName(), RandomVersion(), RandomDigest()
-		err := nodes[0].CreateRepository(name)
+		err := metadata[0].CreateRepository(name)
 		RequireNoError(t, err)
 
-		err = nodes[0].PutTag(name, tag, digest)
+		err = metadata[0].PutTag(name, tag, digest)
 		AssertNoError(t, err)
 
 		time.Sleep(1 * time.Millisecond)
 
-		for _, n := range nodes {
-			got, err := n.GetTag(name, tag)
+		for _, s := range metadata {
+			got, err := s.GetTag(name, tag)
 			AssertNoError(t, err)
 			AssertEqual(t, got, digest)
 		}
 
-		err = nodes[0].DeleteTag(name, tag)
+		err = metadata[0].DeleteTag(name, tag)
 		AssertNoError(t, err)
 
 		time.Sleep(1 * time.Millisecond)
 
-		for _, n := range nodes {
-			_, err := n.GetTag(name, tag)
+		for _, s := range metadata {
+			_, err := s.GetTag(name, tag)
 			AssertErrorIs(t, err, store.ErrNotFound)
 		}
 	})
 
 	t.Run("Ensure upload session metadata is replicated", func(t *testing.T) {
 		name := RandomName()
-		err := nodes[0].CreateRepository(name)
+		err := metadata[0].CreateRepository(name)
 		RequireNoError(t, err)
 
 		id, _ := uuid.NewV7()
 		session := &store.UploadSession{ID: id}
 
-		err = nodes[0].PutUploadSession(name, session)
+		err = metadata[0].PutUploadSession(name, session)
 		AssertNoError(t, err)
 
 		time.Sleep(1 * time.Millisecond)
 
-		for _, n := range nodes {
-			got, err := n.GetUploadSession(name, id.String())
+		for _, s := range metadata {
+			got, err := s.GetUploadSession(name, id.String())
 			AssertNoError(t, err)
 			AssertStructsEqual(t, got, session)
 		}
 
-		err = nodes[0].DeleteUploadSession(name, id.String())
+		err = metadata[0].DeleteUploadSession(name, id.String())
 		AssertNoError(t, err)
 
 		time.Sleep(1 * time.Millisecond)
 
-		for _, n := range nodes {
-			_, err := n.GetUploadSession(name, id.String())
+		for _, s := range metadata {
+			_, err := s.GetUploadSession(name, id.String())
 			AssertErrorIs(t, err, store.ErrNotFound)
 		}
 	})

--- a/store/cluster/metadata.go
+++ b/store/cluster/metadata.go
@@ -1,0 +1,164 @@
+package cluster
+
+import (
+	"math/rand/v2"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/robinkb/cascade-registry/cluster"
+	"github.com/robinkb/cascade-registry/store"
+)
+
+func NewMetadataStore(node cluster.Node, metadata store.Metadata) store.Metadata {
+	s := &metadataStore{
+		Metadata: metadata,
+		node:     node,
+	}
+
+	node.Process(&createRepository{}, s.createRepository)
+	node.Process(&deleteRepository{}, s.deleteRepository)
+	node.Process(&putBlob{}, s.putBlob)
+	node.Process(&deleteBlob{}, s.deleteBlob)
+	node.Process(&putManifest{}, s.putManifest)
+	node.Process(&deleteManifest{}, s.deleteManifest)
+	node.Process(&putTag{}, s.putTag)
+	node.Process(&deleteTag{}, s.deleteTag)
+	node.Process(&putUploadSession{}, s.putUploadSession)
+	node.Process(&deleteUploadSession{}, s.deleteUploadSession)
+
+	return s
+}
+
+type metadataStore struct {
+	store.Metadata
+	node cluster.Node
+}
+
+func (s *metadataStore) CreateRepository(name string) error {
+	op := &createRepository{
+		rand.Uint64(),
+		name,
+	}
+	return s.node.Propose(op)
+}
+
+func (s *metadataStore) createRepository(op cluster.Operation) error {
+	v := op.(*createRepository)
+	return s.Metadata.CreateRepository(v.Name)
+}
+
+func (s *metadataStore) DeleteRepository(name string) error {
+	op := &deleteRepository{
+		rand.Uint64(),
+		name,
+	}
+	return s.node.Propose(op)
+}
+
+func (s *metadataStore) deleteRepository(op cluster.Operation) error {
+	v := op.(*deleteRepository)
+	return s.Metadata.DeleteRepository(v.Name)
+}
+
+func (s *metadataStore) PutBlob(name string, digest digest.Digest) error {
+	op := &putBlob{
+		rand.Uint64(),
+		name, digest,
+	}
+	return s.node.Propose(op)
+}
+
+func (s *metadataStore) putBlob(op cluster.Operation) error {
+	v := op.(*putBlob)
+	return s.Metadata.PutBlob(v.Name, v.Digest)
+}
+
+func (s *metadataStore) DeleteBlob(name string, digest digest.Digest) error {
+	op := &deleteBlob{
+		rand.Uint64(),
+		name, digest,
+	}
+	return s.node.Propose(op)
+}
+
+func (s *metadataStore) deleteBlob(op cluster.Operation) error {
+	v := op.(*deleteBlob)
+	return s.Metadata.DeleteBlob(v.Name, v.Digest)
+}
+
+func (s *metadataStore) PutManifest(name string, digest digest.Digest, meta *store.ManifestMetadata) error {
+	op := &putManifest{
+		rand.Uint64(),
+		name, digest, meta,
+	}
+	return s.node.Propose(op)
+}
+
+func (s *metadataStore) putManifest(op cluster.Operation) error {
+	v := op.(*putManifest)
+	return s.Metadata.PutManifest(v.Name, v.Digest, v.Meta)
+}
+
+func (s *metadataStore) DeleteManifest(name string, digest digest.Digest) error {
+	op := &deleteManifest{
+		rand.Uint64(),
+		name, digest,
+	}
+	return s.node.Propose(op)
+}
+
+func (s *metadataStore) deleteManifest(op cluster.Operation) error {
+	v := op.(*deleteManifest)
+	return s.Metadata.DeleteManifest(v.Name, v.Digest)
+}
+
+func (s *metadataStore) PutTag(name, tag string, digest digest.Digest) error {
+	op := &putTag{
+		rand.Uint64(),
+		name, tag, digest,
+	}
+	return s.node.Propose(op)
+}
+
+func (s *metadataStore) putTag(op cluster.Operation) error {
+	v := op.(*putTag)
+	return s.Metadata.PutTag(v.Name, v.Tag, v.Digest)
+}
+
+func (s *metadataStore) DeleteTag(name, tag string) error {
+	op := &deleteTag{
+		rand.Uint64(),
+		name, tag,
+	}
+	return s.node.Propose(op)
+}
+
+func (s *metadataStore) deleteTag(op cluster.Operation) error {
+	v := op.(*deleteTag)
+	return s.Metadata.DeleteTag(v.Name, v.Tag)
+}
+
+func (s *metadataStore) PutUploadSession(name string, session *store.UploadSession) error {
+	op := &putUploadSession{
+		rand.Uint64(),
+		name, session,
+	}
+	return s.node.Propose(op)
+}
+
+func (s *metadataStore) putUploadSession(op cluster.Operation) error {
+	v := op.(*putUploadSession)
+	return s.Metadata.PutUploadSession(v.Name, v.Session)
+}
+
+func (s *metadataStore) DeleteUploadSession(name string, id string) error {
+	op := &deleteUploadSession{
+		rand.Uint64(),
+		name, id,
+	}
+	return s.node.Propose(op)
+}
+
+func (s *metadataStore) deleteUploadSession(op cluster.Operation) error {
+	v := op.(*deleteUploadSession)
+	return s.Metadata.DeleteUploadSession(v.Name, v.SessionID)
+}

--- a/store/cluster/operations.go
+++ b/store/cluster/operations.go
@@ -1,31 +1,24 @@
-package raft
+package cluster
 
 import (
-	"encoding/gob"
-
 	"github.com/opencontainers/go-digest"
 	"github.com/robinkb/cascade-registry/store"
 )
 
 func init() {
-	// Implementers of the operation interface must be registered
-	// with gob so that it can encode then as an operation interface type,
+	// Implementers of the cluster.Operation interface must be registered
+	// with gob so that it can encode then as an Operation interface type,
 	// and decode them back to the concrete type.
-	gob.Register(&createRepository{})
-	gob.Register(&deleteRepository{})
-	gob.Register(&putBlob{})
-	gob.Register(&deleteBlob{})
-	gob.Register(&putManifest{})
-	gob.Register(&deleteManifest{})
-	gob.Register(&putTag{})
-	gob.Register(&deleteTag{})
-	gob.Register(&putUploadSession{})
-	gob.Register(&deleteUploadSession{})
-}
-
-// operation represents an operation that gets commited to the Raft log.
-type operation interface {
-	ID() uint64
+	// gob.Register(&createRepository{})
+	// gob.Register(&deleteRepository{})
+	// gob.Register(&putBlob{})
+	// gob.Register(&deleteBlob{})
+	// gob.Register(&putManifest{})
+	// gob.Register(&deleteManifest{})
+	// gob.Register(&putTag{})
+	// gob.Register(&deleteTag{})
+	// gob.Register(&putUploadSession{})
+	// gob.Register(&deleteUploadSession{})
 }
 
 type createRepository struct {


### PR DESCRIPTION
The initial implementation of `cluster/raft.node` embedded `store.Metadata` so that it implements the `store.Metadata` interface while wrapping the methods that change the metadata store. This PR instead extends the `cluster.Node` interface with the `Propose` and `Process` methods. These make it easier to re-use `cluster.Node`. 