### PR TITLE
Fix storing the last compacted entry

### DIFF
--- a/cluster/raft/storage/deck.go
+++ b/cluster/raft/storage/deck.go
@@ -273,6 +273,19 @@ func (d *Deck) compact() {
 	if len(d.logs) > d.maxLogCount {
 		log := d.logs[0]
 		id := log.ID
+
+		// The CompactionHandler is run _before_ compaction actually occurs
+		// so that the Deck consumer has a full view of the data, including
+		// what is being removed. Technically compaction may fail afterwards
+		// without the application knowing about it, but we're talking
+		// about removing a file and in-memory operations that are well-tested.
+		if d.compactHandler != nil {
+			err := d.compactHandler(log.Counters())
+			if err != nil {
+				panic(err)
+			}
+		}
+
 		logFile := filepath.Join(d.dir, fmt.Sprintf("%020d.log", id))
 		err := os.Remove(logFile)
 		if err != nil {
@@ -283,13 +296,6 @@ func (d *Deck) compact() {
 
 		d.logs = d.logs[1:len(d.logs)]
 		d.offset++
-
-		if d.compactHandler != nil {
-			err := d.compactHandler(log.Counters())
-			if err != nil {
-				panic(err)
-			}
-		}
 	}
 }
 

--- a/cluster/raft/storage/storage.go
+++ b/cluster/raft/storage/storage.go
@@ -83,7 +83,7 @@ func NewLogStorage(dir string, c *DeckConfig) (*LogStorage, error) {
 	// 	}
 	// }()
 
-	l.deck.CompactionHandler(l.compactHandler())
+	l.deck.CompactionHandler(l.compactionHandler())
 
 	return l, nil
 }
@@ -316,25 +316,46 @@ func (l *LogStorage) Append(entries []raftpb.Entry) error {
 	return nil
 }
 
-func (l *LogStorage) compactHandler() CompactionHandler {
-	var newEntry raftpb.Entry
+func (l *LogStorage) compactionHandler() CompactionHandler {
+	var entry raftpb.Entry
 	r := new(Record)
 
 	return func(c Counters) error {
-		err := l.deck.First(TypeEntry, r)
-		if err != nil {
-			return err
-		}
+		for t, count := range c.All() {
+			// We only do something with Entries atm.
+			if t != TypeEntry {
+				continue
+			}
 
-		err = newEntry.Unmarshal(r.Value)
-		if err != nil {
-			return err
-		}
+			err := l.deck.Get(TypeEntry, int(count)-1, r)
+			if err != nil {
+				return err
+			}
 
-		l.compactedEntry = l.firstEntry
-		l.firstEntry = raftpb.Entry{
-			Index: newEntry.Index,
-			Term:  newEntry.Term,
+			err = entry.Unmarshal(r.Value)
+			if err != nil {
+				return err
+			}
+
+			l.compactedEntry = raftpb.Entry{
+				Index: entry.Index,
+				Term:  entry.Term,
+			}
+
+			err = l.deck.Get(TypeEntry, int(count), r)
+			if err != nil {
+				return err
+			}
+
+			err = entry.Unmarshal(r.Value)
+			if err != nil {
+				return err
+			}
+
+			l.firstEntry = raftpb.Entry{
+				Index: entry.Index,
+				Term:  entry.Term,
+			}
 		}
 
 		return nil

--- a/cluster/raft/storage/storage_test.go
+++ b/cluster/raft/storage/storage_test.go
@@ -327,6 +327,7 @@ func TestCompaction(t *testing.T) {
 	AssertNoError(t, err)
 	AssertStructsEqual(t, got2[0], want2[0])
 	// Term of the last compacted entry should still be available as well.
+	// TODO: This is only correct when compacting out one entry. So in reality, never.
 	term, err := store.Term(fi - 1)
 	AssertNoError(t, err)
 	AssertEqual(t, term, want1[0].Index)


### PR DESCRIPTION
Running the `CompactionHandler` _after_ compaction actually limits what `Deck`'s consumer can do about it. And `LogStorage`'s previous approach of simply moving `firstEntry` into `compactedEntry` only works when one Entry has been compacted out. Which is literally never in the real world.