### PR TITLE
Deck: Read improvements and enable Sync

### DIFF
--- a/cluster/raft/storage.go
+++ b/cluster/raft/storage.go
@@ -293,7 +293,7 @@ func (l *DiskStorage) Append(entries []raftpb.Entry) error {
 		}
 	}
 
-	return nil
+	return l.deck.Sync()
 }
 
 // SaveHardState writes the hard state to persistent storage,
@@ -316,7 +316,8 @@ func (l *DiskStorage) SaveHardState(hardState raftpb.HardState) error {
 	}
 
 	l.hardState = hardState
-	return nil
+
+	return l.deck.Sync()
 }
 
 // SaveSnapshot writes the snapshot to persistent storage,
@@ -339,7 +340,8 @@ func (l *DiskStorage) SaveSnapshot(snapshot raftpb.Snapshot) error {
 	}
 
 	l.snapshot = snapshot
-	return nil
+
+	return l.deck.Sync()
 }
 
 func (l *DiskStorage) SaveConfState(cs raftpb.ConfState) {
@@ -351,7 +353,7 @@ func (l *DiskStorage) cutHandler() storage.CutHandler {
 	r := new(storage.Record)
 	buf := new(bytes.Buffer)
 
-	return func(seq uint64) error {
+	return func(seq int64) error {
 		buf.Reset()
 
 		if err := l.deck.Get(TypeEntry, int(l.appliedIndex), r); err != nil {

--- a/cluster/raft/storage.go
+++ b/cluster/raft/storage.go
@@ -28,15 +28,14 @@ func NewDiskStorage(dir string, snap Snapshotter, c *storage.DeckConfig) (*DiskS
 
 	l.deck.ReadAll()
 
-	record := new(storage.Record)
 	if l.deck.Count(TypeEntry) > 0 {
-		err := l.deck.First(TypeEntry, record)
+		value, err := l.deck.First(TypeEntry)
 		if err != nil {
 			return nil, err
 		}
 
 		var entry raftpb.Entry
-		err = entry.Unmarshal(record.Value)
+		err = entry.Unmarshal(value)
 		if err != nil {
 			return nil, err
 		}
@@ -48,13 +47,13 @@ func NewDiskStorage(dir string, snap Snapshotter, c *storage.DeckConfig) (*DiskS
 	}
 
 	if l.deck.Count(TypeHardState) > 0 {
-		err := l.deck.Last(TypeHardState, record)
+		value, err := l.deck.Last(TypeHardState)
 		if err != nil {
 			return nil, err
 		}
 
 		var hardState raftpb.HardState
-		err = hardState.Unmarshal(record.Value)
+		err = hardState.Unmarshal(value)
 		if err != nil {
 			return nil, err
 		}
@@ -63,13 +62,13 @@ func NewDiskStorage(dir string, snap Snapshotter, c *storage.DeckConfig) (*DiskS
 	}
 
 	if l.deck.Count(TypeSnapshot) > 0 {
-		err := l.deck.Last(TypeSnapshot, record)
+		value, err := l.deck.Last(TypeSnapshot)
 		if err != nil {
 			return nil, err
 		}
 
 		var snapshot raftpb.Snapshot
-		err = snapshot.Unmarshal(record.Value)
+		err = snapshot.Unmarshal(value)
 		if err != nil {
 			return nil, err
 		}
@@ -162,18 +161,18 @@ func (l *DiskStorage) Entries(lo, hi, maxSize uint64) ([]raftpb.Entry, error) {
 	var size uint64
 	entries := make([]raftpb.Entry, 0)
 
-	for record, err := range l.deck.Range(TypeEntry, int(lo), int(hi)) {
+	for value, err := range l.deck.Range(TypeEntry, int(lo), int(hi)) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to get entries [lo: %d] [hi: %d]: %w", lo, hi, err)
 		}
 
-		size += uint64(len(record.Value))
+		size += uint64(len(value))
 		if size > maxSize && len(entries) != 0 {
 			return entries, nil
 		}
 
 		var entry raftpb.Entry
-		err = entry.Unmarshal(record.Value)
+		err = entry.Unmarshal(value)
 		if err != nil {
 			return nil, err
 		}
@@ -209,14 +208,13 @@ func (l *DiskStorage) Term(i uint64) (uint64, error) {
 
 	i -= fi
 
-	r := new(storage.Record)
-	err := l.deck.Get(TypeEntry, int(i), r)
+	value, err := l.deck.Get(TypeEntry, int(i))
 	if err != nil {
 		return 0, fmt.Errorf("failed to get term [i: %d] [fi: %d] [li: %d]: %w", i, fi, li, err)
 	}
 
 	var entry raftpb.Entry
-	err = entry.Unmarshal(r.Value)
+	err = entry.Unmarshal(value)
 	if err != nil {
 		return 0, err
 	}
@@ -281,13 +279,13 @@ func (l *DiskStorage) Append(entries []raftpb.Entry) error {
 
 	var err error
 	for _, entry := range entries {
-		record := &storage.Record{Type: TypeEntry, Value: make([]byte, entry.Size())}
-		_, err = entry.MarshalTo(record.Value)
+		value := make([]byte, entry.Size())
+		_, err = entry.MarshalTo(value)
 		if err != nil {
 			return err
 		}
 
-		err = l.deck.Append(record)
+		err = l.deck.Append(TypeEntry, value)
 		if err != nil {
 			return err
 		}
@@ -301,16 +299,13 @@ func (l *DiskStorage) Append(entries []raftpb.Entry) error {
 func (l *DiskStorage) SaveHardState(hardState raftpb.HardState) error {
 	l.callStats.setHardState++
 
-	record := &storage.Record{
-		Type:  TypeHardState,
-		Value: make([]byte, hardState.Size()),
-	}
-	_, err := hardState.MarshalTo(record.Value)
+	value := make([]byte, hardState.Size())
+	_, err := hardState.MarshalTo(value)
 	if err != nil {
 		return err
 	}
 
-	err = l.deck.Append(record)
+	err = l.deck.Append(TypeHardState, value)
 	if err != nil {
 		return err
 	}
@@ -325,16 +320,13 @@ func (l *DiskStorage) SaveHardState(hardState raftpb.HardState) error {
 func (l *DiskStorage) SaveSnapshot(snapshot raftpb.Snapshot) error {
 	l.callStats.applySnapshot++
 
-	record := &storage.Record{
-		Type:  TypeSnapshot,
-		Value: make([]byte, snapshot.Size()),
-	}
-	_, err := snapshot.MarshalTo(record.Value)
+	value := make([]byte, snapshot.Size())
+	_, err := snapshot.MarshalTo(value)
 	if err != nil {
 		return err
 	}
 
-	err = l.deck.Append(record)
+	err = l.deck.Append(TypeSnapshot, value)
 	if err != nil {
 		return err
 	}
@@ -350,17 +342,17 @@ func (l *DiskStorage) SaveConfState(cs raftpb.ConfState) {
 
 func (l *DiskStorage) cutHandler() storage.CutHandler {
 	var entry raftpb.Entry
-	r := new(storage.Record)
 	buf := new(bytes.Buffer)
 
 	return func(seq int64) error {
 		buf.Reset()
 
-		if err := l.deck.Get(TypeEntry, int(l.appliedIndex), r); err != nil {
+		value, err := l.deck.Get(TypeEntry, int(l.appliedIndex))
+		if err != nil {
 			return err
 		}
 
-		if err := entry.Unmarshal(r.Value); err != nil {
+		if err := entry.Unmarshal(value); err != nil {
 			return err
 		}
 
@@ -382,16 +374,12 @@ func (l *DiskStorage) cutHandler() storage.CutHandler {
 			return err
 		}
 
-		return l.deck.Append(&storage.Record{
-			Type:  TypeSnapshot,
-			Value: data,
-		})
+		return l.deck.Append(TypeSnapshot, data)
 	}
 }
 
 func (l *DiskStorage) compactionHandler() storage.CompactionHandler {
 	var entry raftpb.Entry
-	r := new(storage.Record)
 
 	return func(c storage.Counters) error {
 		for t, count := range c.All() {
@@ -400,12 +388,12 @@ func (l *DiskStorage) compactionHandler() storage.CompactionHandler {
 				continue
 			}
 
-			err := l.deck.Get(TypeEntry, int(count)-1, r)
+			value, err := l.deck.Get(TypeEntry, int(count)-1)
 			if err != nil {
 				return err
 			}
 
-			err = entry.Unmarshal(r.Value)
+			err = entry.Unmarshal(value)
 			if err != nil {
 				return err
 			}
@@ -415,12 +403,12 @@ func (l *DiskStorage) compactionHandler() storage.CompactionHandler {
 				Term:  entry.Term,
 			}
 
-			err = l.deck.Get(TypeEntry, int(count), r)
+			value, err = l.deck.Get(TypeEntry, int(count))
 			if err != nil {
 				return err
 			}
 
-			err = entry.Unmarshal(r.Value)
+			err = entry.Unmarshal(value)
 			if err != nil {
 				return err
 			}

--- a/cluster/raft/storage/codec.go
+++ b/cluster/raft/storage/codec.go
@@ -83,7 +83,8 @@ func (e *encoder) Encode(r *Record) (int64, error) {
 	crc := crc64.Checksum(e.buf.Bytes()[crc64.Size:], crc64Table)
 	binary.LittleEndian.PutUint64(e.buf.Bytes(), crc)
 
-	return io.Copy(e.dst, e.buf)
+	n, err := e.dst.Write(e.buf.Bytes())
+	return int64(n), err
 }
 
 // NewDecoder returns a Decoder that reads decoded Records from the io.ReaderAt.

--- a/cluster/raft/storage/codec.go
+++ b/cluster/raft/storage/codec.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"hash/crc64"
 	"io"
 	"log"
@@ -105,7 +106,7 @@ func (d *decoder) DecodeAt(r *Record, off int64) (int64, error) {
 	n, err := d.src.ReadAt(hbuf, off)
 	read += int64(n)
 	if err != nil {
-		return read, err
+		return read, fmt.Errorf("could not read header: %w", err)
 	}
 	// Ensure header is available in the buffer for later CRC calculation,
 	// which includes parts of the header.
@@ -116,7 +117,7 @@ func (d *decoder) DecodeAt(r *Record, off int64) (int64, error) {
 	// But with a pre-allocated file, a lot of the file might be empty.
 	// Treat reading an empty header the same as EOF in that case.
 	if header.isEmpty() {
-		return read, io.EOF
+		return read, fmt.Errorf("%w (empty header)", io.EOF)
 	}
 
 	// Reading the payload.
@@ -132,7 +133,7 @@ func (d *decoder) DecodeAt(r *Record, off int64) (int64, error) {
 		if err == io.EOF {
 			return read, ErrShortRead
 		}
-		return read, err
+		return read, fmt.Errorf("failed to read payload: %w", err)
 	}
 	d.buf.Write(pbuf)
 

--- a/cluster/raft/storage/codec.go
+++ b/cluster/raft/storage/codec.go
@@ -34,9 +34,12 @@ type (
 
 	// Decoder reads decoded Records from the input stream.
 	Decoder interface {
-		// DecodeAt is a wrapper around an io.ReaderAt for decoding Records.
+		// RecordAt is a wrapper around an io.ReaderAt for decoding Records.
 		// It returns the amount of bytes read and an error, if any.
-		DecodeAt(r *Record, off int64) (int64, error)
+		RecordAt(r *Record, off int64) (int64, error)
+		// ValueAt is a wrapper around an io.ReaderAt for reading Record values.
+		// Its behavior is the same as io.ReaderAt.
+		ValueAt(p []byte, off int64) (int, error)
 	}
 )
 
@@ -96,7 +99,7 @@ type decoder struct {
 	buf *bytes.Buffer
 }
 
-func (d *decoder) DecodeAt(r *Record, off int64) (int64, error) {
+func (d *decoder) RecordAt(r *Record, off int64) (int64, error) {
 	d.buf.Reset()
 	var read int64
 
@@ -147,6 +150,10 @@ func (d *decoder) DecodeAt(r *Record, off int64) (int64, error) {
 	r.Value = d.buf.Bytes()[RecordHeaderLength : RecordHeaderLength+header.size]
 
 	return read, nil
+}
+
+func (d *decoder) ValueAt(p []byte, off int64) (int, error) {
+	return d.src.ReadAt(p, off)
 }
 
 func parseHeader(b []byte) header {

--- a/cluster/raft/storage/codec_test.go
+++ b/cluster/raft/storage/codec_test.go
@@ -2,6 +2,7 @@ package storage_test
 
 import (
 	"bytes"
+	"fmt"
 	"math/rand/v2"
 	"testing"
 
@@ -18,7 +19,7 @@ func TestEncodeDecode(t *testing.T) {
 	AssertNoError(t, err)
 
 	r := bytes.NewReader(w.Bytes())
-	read, err := storage.NewDecoder(r).DecodeAt(got, 0)
+	read, err := storage.NewDecoder(r).RecordAt(got, 0)
 	AssertNoError(t, err).Require()
 
 	AssertEqual(t, written, int64(storage.RecordHeaderLength+len(want.Value)))
@@ -45,7 +46,7 @@ func TestDecodeAllRecords(t *testing.T) {
 	cursor := int64(0)
 	for i := range want {
 		got[i] = new(storage.Record)
-		n, err := dec.DecodeAt(got[i], cursor)
+		n, err := dec.RecordAt(got[i], cursor)
 		AssertNoError(t, err).Require()
 		AssertEqual(t, n, int64(storage.RecordHeaderLength+len(want[i].Value)))
 		AssertStructsEqual(t, got[i], want[i])
@@ -56,9 +57,78 @@ func TestDecodeAllRecords(t *testing.T) {
 	// Now try to read them out again in reverse.
 	for i := len(pos) - 1; i <= 0; i-- {
 		rec := new(storage.Record)
-		_, err := dec.DecodeAt(got[i], pos[i])
+		_, err := dec.RecordAt(got[i], pos[i])
 		AssertNoError(t, err).Require()
 		AssertStructsEqual(t, rec, got[i])
+	}
+}
+
+func TestDecodeValue(t *testing.T) {
+	want := randomRecord(rand.Int64N(128) + 128)
+
+	w := new(bytes.Buffer)
+	_, err := storage.NewEncoder(w).Encode(want)
+	AssertNoError(t, err)
+
+	got := make([]byte, len(want.Value))
+	r := bytes.NewReader(w.Bytes())
+	_, err = storage.NewDecoder(r).ValueAt(got, storage.RecordHeaderLength)
+	AssertNoError(t, err)
+	AssertSlicesEqual(t, got, want.Value)
+}
+
+/*
+Proving that yes, ValueAt is way, WAY faster. Especially for small values.
+
+goos: linux
+goarch: amd64
+pkg: github.com/robinkb/cascade-registry/cluster/raft/storage
+cpu: AMD Ryzen 7 7840U w/ Radeon  780M Graphics
+BenchmarkDecode/RecordSize:_272,_RecordAt-16         	 2637667	       454.0 ns/op	 	599.17 MB/s
+BenchmarkDecode/RecordSize:_272,_ValueAt-16            175557979	         6.702 ns/op	38199.31 MB/s
+BenchmarkDecode/RecordSize:_1040,_RecordAt-16        	  675166	      1730 ns/op	 	601.21 MB/s
+BenchmarkDecode/RecordSize:_1040,_ValueAt-16         	85390696	        11.90 ns/op		86035.17 MB/s
+BenchmarkDecode/RecordSize:_32784,_RecordAt-16       	   81692	     14653 ns/op		2237.34 MB/s
+BenchmarkDecode/RecordSize:_32784,_ValueAt-16        	 2650680	       449.6 ns/op		72876.08 MB/s
+BenchmarkDecode/RecordSize:_65552,_RecordAt-16       	   42962	     27951 ns/op		2345.28 MB/s
+BenchmarkDecode/RecordSize:_65552,_ValueAt-16        	 1331488	       900.6 ns/op		72770.52 MB/s
+BenchmarkDecode/RecordSize:_131088,_RecordAt-16      	   21730	     55011 ns/op		2382.93 MB/s
+BenchmarkDecode/RecordSize:_131088,_ValueAt-16       	  618614	      1795 ns/op		73029.26 MB/s
+*/
+func BenchmarkDecode(b *testing.B) {
+	tc := []struct {
+		record *storage.Record
+	}{
+		{randomRecord(256)},
+		{randomRecord(1 << 10)},
+		{randomRecord(32 << 10)},
+		{randomRecord(64 << 10)},
+		{randomRecord(128 << 10)},
+	}
+
+	for _, tt := range tc {
+		w := new(bytes.Buffer)
+		storage.NewEncoder(w).Encode(tt.record)
+
+		r := bytes.NewReader(w.Bytes())
+		dec := storage.NewDecoder(r)
+
+		b.Run(fmt.Sprintf("RecordSize: %d, RecordAt", tt.record.Size()), func(b *testing.B) {
+			record := new(storage.Record)
+			for b.Loop() {
+				b.SetBytes(record.Size())
+				dec.RecordAt(record, 0)
+			}
+		})
+
+		b.Run(fmt.Sprintf("RecordSize: %d, ValueAt", tt.record.Size()), func(b *testing.B) {
+			p := make([]byte, len(tt.record.Value))
+			size := int64(len(p))
+			for b.Loop() {
+				b.SetBytes(size)
+				dec.ValueAt(p, storage.RecordHeaderLength)
+			}
+		})
 	}
 }
 
@@ -73,7 +143,7 @@ func TestEncodeDecodeErrorDetection(t *testing.T) {
 		w.Truncate(100)
 
 		r := bytes.NewReader(w.Bytes())
-		_, err = storage.NewDecoder(r).DecodeAt(got, 0)
+		_, err = storage.NewDecoder(r).RecordAt(got, 0)
 		AssertErrorIs(t, err, storage.ErrShortRead)
 	})
 
@@ -90,7 +160,7 @@ func TestEncodeDecodeErrorDetection(t *testing.T) {
 		w.Write(b)
 
 		r := bytes.NewReader(w.Bytes())
-		_, err = storage.NewDecoder(r).DecodeAt(got, 0)
+		_, err = storage.NewDecoder(r).RecordAt(got, 0)
 		AssertErrorIs(t, err, storage.ErrChecksumMismatch)
 	})
 }
@@ -108,7 +178,7 @@ func TestEncodeDecodeDoesNotAllocate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, err = decoder.DecodeAt(dst, 0)
+		_, err = decoder.RecordAt(dst, 0)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cluster/raft/storage/codec_test.go
+++ b/cluster/raft/storage/codec_test.go
@@ -108,7 +108,7 @@ func BenchmarkDecode(b *testing.B) {
 
 	for _, tt := range tc {
 		w := new(bytes.Buffer)
-		storage.NewEncoder(w).Encode(tt.record)
+		storage.NewEncoder(w).Encode(tt.record) // nolint: errcheck
 
 		r := bytes.NewReader(w.Bytes())
 		dec := storage.NewDecoder(r)
@@ -117,7 +117,7 @@ func BenchmarkDecode(b *testing.B) {
 			record := new(storage.Record)
 			for b.Loop() {
 				b.SetBytes(record.Size())
-				dec.RecordAt(record, 0)
+				dec.RecordAt(record, 0) // nolint: errcheck
 			}
 		})
 
@@ -126,7 +126,7 @@ func BenchmarkDecode(b *testing.B) {
 			size := int64(len(p))
 			for b.Loop() {
 				b.SetBytes(size)
-				dec.ValueAt(p, storage.RecordHeaderLength)
+				dec.ValueAt(p, storage.RecordHeaderLength) // nolint: errcheck
 			}
 		})
 	}

--- a/cluster/raft/storage/deck.go
+++ b/cluster/raft/storage/deck.go
@@ -238,9 +238,12 @@ func (d *Deck) readAt(r *Record, p Pointer) error {
 func (d *Deck) ReadAll() {
 	for _, log := range d.logs {
 		for record := range log.All() {
+			offset, size := log.Pointer()
+
 			d.inventory.Add(record.Type, Pointer{
 				Log:    log.ID,
-				Offset: log.Pointer(),
+				Offset: offset,
+				Size:   size,
 			})
 		}
 	}
@@ -330,13 +333,22 @@ func (d *Deck) compact() {
 
 // Pointer returns the location of the Record last written to the Deck.
 func (d *Deck) Pointer() Pointer {
+	log := d.activeLog()
+	offset, size := log.Pointer()
+
 	return Pointer{
-		Log:    d.logs[len(d.logs)-1].ID,
-		Offset: d.logs[len(d.logs)-1].Pointer(),
+		Log:    log.ID,
+		Offset: offset,
+		Size:   size,
 	}
 }
 
+// Pointer points to the location and size of a Record's Value in a Log.
 type Pointer struct {
-	Log    int64
+	// Log is the ID of the Log within the Deck that Value resides in.
+	Log int64
+	// Offset is the position within the Log that the Value starts at.
 	Offset int64
+	// Size is the length of the Value in bytes.
+	Size int64
 }

--- a/cluster/raft/storage/deck.go
+++ b/cluster/raft/storage/deck.go
@@ -178,9 +178,9 @@ func (d *Deck) Append(r *Record) error {
 	return nil
 }
 
-// func (d *Deck) Sync() error {
-// 	return d.activeLog().Sync()
-// }
+func (d *Deck) Sync() error {
+	return syscall.Fdatasync(int(d.activeLog().File.Fd()))
+}
 
 func (d *Deck) Get(t RecordType, i int, r *Record) error {
 	ptr, err := d.inventory.Get(t, i)

--- a/cluster/raft/storage/deck.go
+++ b/cluster/raft/storage/deck.go
@@ -158,7 +158,12 @@ type Deck struct {
 	compactHandler CompactionHandler
 }
 
-func (d *Deck) Append(r *Record) error {
+func (d *Deck) Append(t RecordType, value []byte) error {
+	r := &Record{
+		Type:  t,
+		Value: value,
+	}
+
 	log := d.activeLog()
 	if log.cursor+r.Size() > d.maxLogSize {
 		log = d.newLog()

--- a/cluster/raft/storage/deck.go
+++ b/cluster/raft/storage/deck.go
@@ -27,7 +27,7 @@ type DeckConfig struct {
 }
 
 type CompactionHandler func(c Counters) error
-type CutHandler func(seq uint64) error
+type CutHandler func(seq int64) error
 
 var defaultDeckConfig = DeckConfig{
 	MaxLogSize:  64 << 20,
@@ -38,7 +38,7 @@ var logNameRe = regexp.MustCompile(`(\d{20}).log`)
 
 func NewDeck(dir string, c *DeckConfig) Deck {
 	d := Deck{
-		logs: make([]*Log, 0),
+		logs: make([]ManagedLog, 0),
 
 		dir:         dir,
 		maxLogSize:  defaultDeckConfig.MaxLogSize,
@@ -109,23 +109,29 @@ func NewDeck(dir string, c *DeckConfig) Deck {
 			panic(err)
 		}
 
-		log := NewLog(r, w)
-		log.ID = id
-		d.logs = append(d.logs, log)
+		d.logs = append(d.logs, ManagedLog{
+			ID:   id,
+			File: w,
+			Log:  NewLog(r, w),
+		})
 		d.sequence++
 	}
 
 	return d
 }
 
-type LogIndex struct {
-	Log *Log
-	ID  uint64
+// ManagedLog represents a Log that is managed by a Deck.
+// It wraps the basic Log and adds an ID for tracking unique Logs,
+// and the handle of the underlying file.
+type ManagedLog struct {
+	*Log
+	ID   int64
+	File *os.File
 }
 
 // Deck is an organized collection of Logs.
 type Deck struct {
-	logs []*Log
+	logs []ManagedLog
 	// dir is the directory where the Logs are stored on-disk.
 	dir string
 	// sequence holds the ID of the last log created.
@@ -171,6 +177,10 @@ func (d *Deck) Append(r *Record) error {
 
 	return nil
 }
+
+// func (d *Deck) Sync() error {
+// 	return d.activeLog().Sync()
+// }
 
 func (d *Deck) Get(t RecordType, i int, r *Record) error {
 	ptr, err := d.inventory.Get(t, i)
@@ -244,7 +254,7 @@ func (d *Deck) CompactionHandler(h CompactionHandler) {
 	d.compactHandler = h
 }
 
-func (d *Deck) newLog() *Log {
+func (d *Deck) newLog() ManagedLog {
 	logFile := filepath.Join(d.dir, fmt.Sprintf("%020d.log", d.sequence))
 
 	w, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY, 0644)
@@ -261,21 +271,26 @@ func (d *Deck) newLog() *Log {
 		panic(err)
 	}
 
-	log := NewLog(r, w)
-	log.ID = int64(d.sequence)
+	log := ManagedLog{
+		Log:  NewLog(r, w),
+		ID:   int64(d.sequence),
+		File: w,
+	}
 	d.logs = append(d.logs, log)
+
 	if d.cutHandler != nil && d.sequence != 0 {
-		err := d.cutHandler(uint64(log.ID))
+		err := d.cutHandler(log.ID)
 		if err != nil {
 			panic(err)
 		}
 	}
+
 	d.sequence++
 
 	return log
 }
 
-func (d *Deck) activeLog() *Log {
+func (d *Deck) activeLog() ManagedLog {
 	if len(d.logs) == 0 {
 		return d.newLog()
 	}

--- a/cluster/raft/storage/deck.go
+++ b/cluster/raft/storage/deck.go
@@ -173,7 +173,9 @@ func (d *Deck) Append(r *Record) error {
 
 	// Run compaction _after_ adding the new entry so that
 	// the compaction handler has an up-to-date view of the Deck.
-	d.compact()
+	if len(d.logs) > d.maxLogCount {
+		d.compact()
+	}
 
 	return nil
 }
@@ -182,57 +184,60 @@ func (d *Deck) Sync() error {
 	return syscall.Fdatasync(int(d.activeLog().File.Fd()))
 }
 
-func (d *Deck) Get(t RecordType, i int, r *Record) error {
+func (d *Deck) Get(t RecordType, i int) ([]byte, error) {
 	ptr, err := d.inventory.Get(t, i)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return d.readAt(r, ptr)
+	return d.valueAt(ptr)
 }
 
 func (d *Deck) Count(t RecordType) int {
 	return d.inventory.Count(t)
 }
 
-func (d *Deck) First(t RecordType, r *Record) error {
+func (d *Deck) First(t RecordType) ([]byte, error) {
 	ptr, err := d.inventory.Get(t, 0)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return d.readAt(r, ptr)
+	return d.valueAt(ptr)
 }
 
-func (d *Deck) Last(t RecordType, r *Record) error {
+func (d *Deck) Last(t RecordType) ([]byte, error) {
 	ptr, err := d.inventory.Get(t, d.inventory.Count(t)-1)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return d.readAt(r, ptr)
+	return d.valueAt(ptr)
 }
 
-func (d *Deck) Range(t RecordType, lo, hi int) iter.Seq2[*Record, error] {
-	return func(yield func(*Record, error) bool) {
+func (d *Deck) Range(t RecordType, lo, hi int) iter.Seq2[[]byte, error] {
+	return func(yield func([]byte, error) bool) {
 		pointers, err := d.inventory.Range(t, lo, hi)
 		if err != nil {
 			yield(nil, err)
 			return
 		}
 
-		r := new(Record)
 		for _, ptr := range pointers {
-			err := d.readAt(r, ptr)
-			if !yield(r, err) {
+			b, err := d.valueAt(ptr)
+			if !yield(b, err) {
 				return
 			}
 		}
 	}
 }
 
-func (d *Deck) readAt(r *Record, p Pointer) error {
-	return d.logs[p.Log-d.offset].ReadAt(r, p.Offset)
+// This allocates, after all the hard work of making sure that nothing does.
+// What to do? Maybe use a buffer pool?
+func (d *Deck) valueAt(p Pointer) ([]byte, error) {
+	value := make([]byte, p.Size)
+	err := d.logs[p.Log-d.offset].ValueAt(value, p.Offset)
+	return value, err
 }
 
 func (d *Deck) ReadAll() {
@@ -302,33 +307,31 @@ func (d *Deck) activeLog() ManagedLog {
 
 // TODO: Should close Log's file descriptors here...?
 func (d *Deck) compact() {
-	if len(d.logs) > d.maxLogCount {
-		log := d.logs[0]
-		id := log.ID
+	log := d.logs[0]
+	id := log.ID
 
-		// The CompactionHandler is run _before_ compaction actually occurs
-		// so that the Deck consumer has a full view of the data, including
-		// what is being removed. Technically compaction may fail afterwards
-		// without the application knowing about it, but we're talking
-		// about removing a file and in-memory operations that are well-tested.
-		if d.compactHandler != nil {
-			err := d.compactHandler(log.Counters())
-			if err != nil {
-				panic(err)
-			}
-		}
-
-		logFile := filepath.Join(d.dir, fmt.Sprintf("%020d.log", id))
-		err := os.Remove(logFile)
+	// The CompactionHandler is run _before_ compaction actually occurs
+	// so that the Deck consumer has a full view of the data, including
+	// what is being removed. Technically compaction may fail afterwards
+	// without the application knowing about it, but we're talking
+	// about removing a file and in-memory operations that are well-tested.
+	if d.compactHandler != nil {
+		err := d.compactHandler(log.Counters())
 		if err != nil {
 			panic(err)
 		}
-
-		d.inventory.Remove(log.Counters())
-
-		d.logs = d.logs[1:len(d.logs)]
-		d.offset++
 	}
+
+	logFile := filepath.Join(d.dir, fmt.Sprintf("%020d.log", id))
+	err := os.Remove(logFile)
+	if err != nil {
+		panic(err)
+	}
+
+	d.inventory.Remove(log.Counters())
+
+	d.logs = d.logs[1:len(d.logs)]
+	d.offset++
 }
 
 // Pointer returns the location of the Record last written to the Deck.

--- a/cluster/raft/storage/deck_test.go
+++ b/cluster/raft/storage/deck_test.go
@@ -12,14 +12,14 @@ import (
 )
 
 func TestNoSé(t *testing.T) {
-	want := randomRecordsN(10, 150, 200)
+	want := RandomContentsN(10, 150, 200)
 	d := storage.NewDeck(t.TempDir(), &storage.DeckConfig{
 		MaxLogSize:  256,
 		MaxLogCount: 5,
 	})
 
 	for i := range want {
-		err := d.Append(want[i])
+		err := d.Append(randomRecordType(), want[i])
 		AssertNoError(t, err).Require()
 	}
 }
@@ -29,7 +29,7 @@ func TestDeckInNewDirectory(t *testing.T) {
 	d := storage.NewDeck(path, nil)
 
 	// Write whatever to force Deck to create a file.
-	err := d.Append(randomRecord(128))
+	err := d.Append(randomRecordType(), RandomContents(128))
 	AssertNoError(t, err)
 }
 
@@ -72,16 +72,15 @@ func BenchmarkDeckAppend(b *testing.B) {
 			path := filepath.Join(b.TempDir(), RandomString(8))
 			deck := storage.NewDeck(path, nil)
 
-			r := new(storage.Record)
-			r.Value = make([]byte, tt.size)
+			value := make([]byte, tt.size)
 
 			for b.Loop() {
-				b.SetBytes(r.Size())
+				b.SetBytes(int64(tt.size) + storage.RecordHeaderLength)
 
-				r.Type = storage.RecordType(rand.Uint64())
-				crand.Read(r.Value)
+				t := storage.RecordType(rand.Uint64())
+				crand.Read(value)
 
-				deck.Append(r)
+				deck.Append(t, value)
 				if tt.sync {
 					deck.Sync()
 				}

--- a/cluster/raft/storage/deck_test.go
+++ b/cluster/raft/storage/deck_test.go
@@ -1,6 +1,8 @@
 package storage_test
 
 import (
+	crand "crypto/rand"
+	"fmt"
 	"math/rand/v2"
 	"path/filepath"
 	"testing"
@@ -29,6 +31,63 @@ func TestDeckInNewDirectory(t *testing.T) {
 	// Write whatever to force Deck to create a file.
 	err := d.Append(randomRecord(128))
 	AssertNoError(t, err)
+}
+
+/*
+*
+Results on 20/07/2025 at commit 53877d9608fc8a
+
+goos: linux
+goarch: amd64
+pkg: github.com/robinkb/cascade-registry/cluster/raft/storage
+cpu: AMD Ryzen 7 7840U w/ Radeon  780M Graphics
+BenchmarkDeckAppend/RecordSize:1kB_Sync:false-16         	  264784	      4462 ns/op	 233.07 MB/s	     247 B/op	       1 allocs/op
+BenchmarkDeckAppend/RecordSize:32kB_Sync:false-16        	   20526	     57973 ns/op	 565.50 MB/s	     238 B/op	       1 allocs/op
+BenchmarkDeckAppend/RecordSize:64kB_Sync:false-16        	    9496	    114859 ns/op	 570.72 MB/s	     305 B/op	       1 allocs/op
+BenchmarkDeckAppend/RecordSize:128kB_Sync:false-16       	    5356	    223121 ns/op	 587.52 MB/s	     499 B/op	       1 allocs/op
+BenchmarkDeckAppend/RecordSize:1kB_Sync:true-16          	  250089	      4660 ns/op	 223.20 MB/s	     252 B/op	       1 allocs/op
+BenchmarkDeckAppend/RecordSize:32kB_Sync:true-16         	   17704	     58852 ns/op	 557.06 MB/s	     256 B/op	       1 allocs/op
+BenchmarkDeckAppend/RecordSize:64kB_Sync:true-16         	   10497	    113176 ns/op	 579.20 MB/s	     291 B/op	       1 allocs/op
+BenchmarkDeckAppend/RecordSize:128kB_Sync:true-16        	    5031	    226418 ns/op	 578.96 MB/s	     495 B/op	       1 allocs/op
+PASS
+*/
+func BenchmarkDeckAppend(b *testing.B) {
+	tc := []struct {
+		size int
+		sync bool
+	}{
+		{1 << 10, false},
+		{32 << 10, false},
+		{64 << 10, false},
+		{128 << 10, false},
+		{1 << 10, true},
+		{32 << 10, true},
+		{64 << 10, true},
+		{128 << 10, true},
+	}
+
+	for _, tt := range tc {
+		name := fmt.Sprintf("RecordSize:%dkB Sync:%t", tt.size/1024, tt.sync)
+		b.Run(name, func(b *testing.B) {
+			path := filepath.Join(b.TempDir(), RandomString(8))
+			deck := storage.NewDeck(path, nil)
+
+			r := new(storage.Record)
+			r.Value = make([]byte, tt.size)
+
+			for b.Loop() {
+				b.SetBytes(r.Size())
+
+				r.Type = storage.RecordType(rand.Uint64())
+				crand.Read(r.Value)
+
+				deck.Append(r)
+				if tt.sync {
+					deck.Sync()
+				}
+			}
+		})
+	}
 }
 
 func randomRecordsN(n int, minSize, maxSize int64) []*storage.Record {

--- a/cluster/raft/storage/deck_test.go
+++ b/cluster/raft/storage/deck_test.go
@@ -78,11 +78,11 @@ func BenchmarkDeckAppend(b *testing.B) {
 				b.SetBytes(int64(tt.size) + storage.RecordHeaderLength)
 
 				t := storage.RecordType(rand.Uint64())
-				crand.Read(value)
+				crand.Read(value) // nolint: errcheck
 
-				deck.Append(t, value)
+				deck.Append(t, value) // nolint: errcheck
 				if tt.sync {
-					deck.Sync()
+					deck.Sync() // nolint: errcheck
 				}
 			}
 		})

--- a/cluster/raft/storage/inventory_test.go
+++ b/cluster/raft/storage/inventory_test.go
@@ -178,5 +178,6 @@ func randomPointer() storage.Pointer {
 	return storage.Pointer{
 		Log:    rand.Int64(),
 		Offset: rand.Int64(),
+		Size:   rand.Int64(),
 	}
 }

--- a/cluster/raft/storage/log.go
+++ b/cluster/raft/storage/log.go
@@ -37,7 +37,7 @@ func (l *Log) Append(r *Record) error {
 }
 
 func (l *Log) ReadAt(r *Record, offset int64) error {
-	_, err := l.dec.DecodeAt(r, offset)
+	_, err := l.dec.RecordAt(r, offset)
 	return err
 }
 
@@ -45,7 +45,7 @@ func (l *Log) All() iter.Seq[*Record] {
 	return func(yield func(*Record) bool) {
 		r := new(Record)
 		for {
-			n, err := l.dec.DecodeAt(r, l.cursor)
+			n, err := l.dec.RecordAt(r, l.cursor)
 			if err != nil {
 				if errors.Is(err, io.EOF) {
 					return

--- a/cluster/raft/storage/log.go
+++ b/cluster/raft/storage/log.go
@@ -16,8 +16,6 @@ func NewLog(r io.ReaderAt, w io.Writer) *Log {
 }
 
 type Log struct {
-	ID int64
-
 	enc Encoder
 	dec Decoder
 	// cursor tracks the position of writes to the log.
@@ -26,6 +24,8 @@ type Log struct {
 	// pointer contains the starting position of the last record
 	// written to the log.
 	pointer int64
+	// lastValueSize is the size of the last Record's Value written to the log.
+	lastValueSize int64
 	// counters tracks how many records of each type is in the Log.
 	counters Counters
 }
@@ -65,8 +65,8 @@ func (l *Log) Counters() Counters {
 	return l.counters
 }
 
-func (l *Log) Pointer() int64 {
-	return l.pointer
+func (l *Log) Pointer() (int64, int64) {
+	return l.pointer + RecordHeaderLength, l.lastValueSize
 }
 
 func (l *Log) Rewind() {
@@ -77,5 +77,6 @@ func (l *Log) Rewind() {
 func (l *Log) advance(n int64, t RecordType) {
 	l.pointer = l.cursor
 	l.cursor += n
+	l.lastValueSize = n - RecordHeaderLength
 	l.counters.Add(t)
 }

--- a/cluster/raft/storage/log.go
+++ b/cluster/raft/storage/log.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"errors"
 	"io"
 	"iter"
 	"log"
@@ -46,7 +47,7 @@ func (l *Log) All() iter.Seq[*Record] {
 		for {
 			n, err := l.dec.DecodeAt(r, l.cursor)
 			if err != nil {
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					return
 				}
 				log.Panicln("error while reading log:", err)

--- a/cluster/raft/storage/log.go
+++ b/cluster/raft/storage/log.go
@@ -36,8 +36,8 @@ func (l *Log) Append(r *Record) error {
 	return err
 }
 
-func (l *Log) ReadAt(r *Record, offset int64) error {
-	_, err := l.dec.RecordAt(r, offset)
+func (l *Log) ValueAt(p []byte, offset int64) error {
+	_, err := l.dec.ValueAt(p, offset)
 	return err
 }
 

--- a/cmd/dump/main.go
+++ b/cmd/dump/main.go
@@ -39,7 +39,8 @@ func main() {
 			if err != nil {
 				log.Fatalln(err)
 			}
-			fmt.Printf("%20d:%-6d [entry   ] index %d, term %d, type %s\n", l.Pointer(), r.Size(), entry.Index, entry.Term, entry.Type.String())
+			offset, size := l.Pointer()
+			fmt.Printf("%20d:%-6d [entry   ] index %d, term %d, type %s\n", offset, size, entry.Index, entry.Term, entry.Type.String())
 
 		case raft.TypeHardState:
 			var hs raftpb.HardState
@@ -47,7 +48,8 @@ func main() {
 			if err != nil {
 				log.Fatalln(err)
 			}
-			fmt.Printf("%20d:%-6d [state   ] commit %d, term %d, vote %d\n", l.Pointer(), r.Size(), hs.Commit, hs.Term, hs.Vote)
+			offset, size := l.Pointer()
+			fmt.Printf("%20d:%-6d [state   ] commit %d, term %d, vote %d\n", offset, size, hs.Commit, hs.Term, hs.Vote)
 
 		case raft.TypeSnapshot:
 			var snap raftpb.Snapshot
@@ -55,7 +57,8 @@ func main() {
 			if err != nil {
 				log.Fatalln(err)
 			}
-			fmt.Printf("%20d:%-6d [snapshot] index %d, term %d, confState %s\n", l.Pointer(), r.Size(), snap.Metadata.Index, snap.Metadata.Term, snap.Metadata.ConfState.String())
+			offset, size := l.Pointer()
+			fmt.Printf("%20d:%-6d [snapshot] index %d, term %d, confState %s\n", offset, size, snap.Metadata.Index, snap.Metadata.Term, snap.Metadata.ConfState.String())
 		}
 	}
 }

--- a/testing/random.go
+++ b/testing/random.go
@@ -35,6 +35,14 @@ func RandomContents(length int64) []byte {
 	return data
 }
 
+func RandomContentsN(n int, minSize, maxSize int64) [][]byte {
+	values := make([][]byte, n)
+	for i := range values {
+		values[i] = RandomContents(rand.Int64N(maxSize-minSize) + minSize)
+	}
+	return values
+}
+
 func RandomString(length int) string {
 	data := make([]byte, length)
 	for i := range data {


### PR DESCRIPTION
Implement some improvements in read performance, and rework the API a bit.

Most significant improvements are:

* Use byte slices instead of Records in Deck's API
* Enable reading just values instead of complete records and use that everywhere

Implements some points from #71, but not all.