### PR TITLE
LogDeckDB: Add Cut and Compact methods

### DIFF
--- a/cluster/raft/logdeck/db.go
+++ b/cluster/raft/logdeck/db.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -35,6 +36,16 @@ type (
 		// Range returns an iterator that ranges over all values of Type t
 		// in the range [lo, hi[.
 		Range(t Type, lo, hi int) iter.Seq2[[]byte, error]
+		// Cut manually cuts a new Log in the DB. Cutting a Log is normally
+		// triggered automatically when MaxLogSize or MaxLogRecordCount is
+		// exceeded. Instead, Cut may be used to trigger them manually when more
+		// control is required, like for tests.
+		Cut() error
+		// Compact manually triggers a compaction. Compactions are normally
+		// triggered automatically when MaxLogCount is exceeded. Instead,
+		// Compact may be used to trigger them manually when more control
+		// is required, like for tests.
+		// Compact() error
 		// CutHook registers CutHookFunc f, which is run whenever a Log is cut.
 		// To clear the CutHook, call CutHook with a nil argument.
 		CutHook(f CutHookFunc)
@@ -73,19 +84,24 @@ type (
 		// MaxLogSize determines the maximum size that a single Log in the DB can have.
 		// When appending a value to a Log would make it grow larger than MaxLogSize,
 		// a new Log is provisioned, and the value is appended to the new Log.
-		// The total maximum DB size on disk is MaxLogSize * MaxLogCount.
+		// The total maximum DB size on disk is MaxLogSize * (MaxLogCount + 1).
 		MaxLogSize int64
+		// MaxLogRecordCount determines the maximum amount of records that a single Log in the DB can have.
+		// When appnding a value to a Log would make it exceed MaxLogRecordCount,
+		// a new Log is provisioned, and the value is appended to the new Log.
+		MaxLogRecordCount int64
 		// MaxLogCount determines how many Logs can be contained in the DB.
 		// Once exceeded, the oldest Log in the DB is compacted.
-		// The total maximum DB size on disk is MaxLogSize * MaxLogCount.
+		// The total maximum DB size on disk is MaxLogSize * (MaxLogCount + 1).
 		MaxLogCount int
 	}
 )
 
 // DefaultOptions defines the default Options values.
 var DefaultOptions = &Options{
-	MaxLogSize:  64 << 20,
-	MaxLogCount: 16,
+	MaxLogRecordCount: math.MaxInt64,
+	MaxLogSize:        64 << 20,
+	MaxLogCount:       16,
 }
 
 // Open intializes a DB in directory dir. If the directory already contains
@@ -315,6 +331,11 @@ func (d *db) ReadAll() {
 	}
 }
 
+func (d *db) Cut() error {
+	_, err := d.cut()
+	return err
+}
+
 func (d *db) CutHook(h CutHookFunc) {
 	d.cutHook = h
 }
@@ -384,11 +405,10 @@ func (d *db) compact() error {
 	log := d.logs[0]
 	id := log.ID
 
-	// The CompactionHandler is run _before_ compaction actually occurs
+	// The CompactHook is run _before_ compaction actually occurs
 	// so that the Deck consumer has a full view of the data, including
-	// what is being removed. Technically compaction may fail afterwards
-	// without the application knowing about it, but we're talking
-	// about removing a file and in-memory operations that are well-tested.
+	// what is being removed. An errors encountered by compaction are surfaced
+	// to the application.
 	if d.compactHook != nil {
 		err := d.compactHook(log.Counters())
 		if err != nil {

--- a/cluster/raft/logdeck/db.go
+++ b/cluster/raft/logdeck/db.go
@@ -39,13 +39,15 @@ type (
 		// Cut manually cuts a new Log in the DB. Cutting a Log is normally
 		// triggered automatically when MaxLogSize or MaxLogRecordCount is
 		// exceeded. Instead, Cut may be used to trigger them manually when more
-		// control is required, like for tests.
+		// control is required, like for tests. As such, Cut does not consider
+		// MaxLogSize and MaxLogRecordCount.
 		Cut() error
 		// Compact manually triggers a compaction. Compactions are normally
 		// triggered automatically when MaxLogCount is exceeded. Instead,
 		// Compact may be used to trigger them manually when more control
-		// is required, like for tests.
-		// Compact() error
+		// is required, like for tests. As such, Compact does not consider MaxLogCount.
+		// Attempting to Compact when the DB only contains one Log returns ErrInvalidCompaction.
+		Compact() error
 		// CutHook registers CutHookFunc f, which is run whenever a Log is cut.
 		// To clear the CutHook, call CutHook with a nil argument.
 		CutHook(f CutHookFunc)
@@ -340,6 +342,10 @@ func (d *db) CutHook(h CutHookFunc) {
 	d.cutHook = h
 }
 
+func (d *db) Compact() error {
+	return d.compact()
+}
+
 func (d *db) CompactHook(h CompactHookFunc) {
 	d.compactHook = h
 }
@@ -402,6 +408,10 @@ func (d *db) cut() (*managedLog, error) {
 
 // TODO: Should close Log's file descriptors here...?
 func (d *db) compact() error {
+	if len(d.logs) <= 1 {
+		return fmt.Errorf("%w: only one Log in DB", ErrInvalidCompaction)
+	}
+
 	log := d.logs[0]
 	id := log.ID
 

--- a/cluster/raft/logdeck/db_test.go
+++ b/cluster/raft/logdeck/db_test.go
@@ -63,10 +63,39 @@ func TestDBGet(t *testing.T) {
 	})
 }
 
-func TestDBCutHook(t *testing.T) {
-	t.Run("Verify that LogID is passed and incremented correctly", func(t *testing.T) {
-		// Need access to internal methods.
+func TestDBCut(t *testing.T) {
+	t.Run("Cut provisions a new Log every time it is called", func(t *testing.T) {
 		db := testDB(t, nil).(*db)
+
+		target := 5
+
+		// Start at 2 because a DB starts with 1 Log.
+		for want := 2; want < target; want++ {
+			err := db.Cut()
+			AssertNoError(t, err)
+
+			got := len(db.logs)
+			AssertEqual(t, got, want)
+		}
+	})
+
+	t.Run("Cut calls CutHook", func(t *testing.T) {
+		db := testDB(t, nil)
+
+		want := true
+		got := false
+		db.CutHook(func(id LogID) error {
+			got = true
+			return nil
+		})
+
+		err := db.Cut()
+		AssertNoError(t, err)
+		AssertEqual(t, got, want)
+	})
+
+	t.Run("LogID is passed to CutHook and incremented correctly", func(t *testing.T) {
+		db := testDB(t, nil)
 
 		var got LogID
 		db.CutHook(func(id LogID) error {
@@ -75,7 +104,7 @@ func TestDBCutHook(t *testing.T) {
 		})
 
 		for want := range 5 {
-			_, err := db.cut()
+			err := db.Cut()
 			AssertNoError(t, err)
 			AssertEqual(t, got, LogID(want))
 		}

--- a/cluster/raft/logdeck/db_test.go
+++ b/cluster/raft/logdeck/db_test.go
@@ -1,6 +1,7 @@
 package logdeck
 
 import (
+	"errors"
 	"math/rand/v2"
 	"os"
 	"testing"
@@ -21,21 +22,19 @@ func TestDBAppend(t *testing.T) {
 	_, err = db.Last(wantType)
 	AssertErrorIs(t, err, ErrTypeUnknown)
 
-	for i, val := range wantValues {
+	for _, val := range wantValues {
 		err := db.Append(wantType, val)
 		AssertNoError(t, err).Require()
-
-		// Make sure that Count and Last account for the new value,
-		// and that First has not changed.
-		count := db.Count(wantType)
-		AssertEqual(t, count, i+1)
-		got, err := db.First(wantType)
-		AssertNoError(t, err)
-		AssertSlicesEqual(t, got, wantValues[0])
-		got, err = db.Last(wantType)
-		AssertNoError(t, err)
-		AssertSlicesEqual(t, got, val)
 	}
+
+	count = db.Count(wantType)
+	AssertEqual(t, count, len(wantValues))
+	got, err := db.First(wantType)
+	AssertNoError(t, err)
+	AssertSlicesEqual(t, got, wantValues[0])
+	got, err = db.Last(wantType)
+	AssertNoError(t, err)
+	AssertSlicesEqual(t, got, wantValues[len(wantValues)-1])
 }
 
 func TestDBGet(t *testing.T) {
@@ -108,6 +107,82 @@ func TestDBCut(t *testing.T) {
 			AssertNoError(t, err)
 			AssertEqual(t, got, LogID(want))
 		}
+	})
+
+	t.Run("Error from CutHook is bubbled up to Cut", func(t *testing.T) {
+		db := testDB(t, nil)
+
+		want := errors.New("error when calling CutHook")
+		db.CutHook(func(id LogID) error {
+			return want
+		})
+
+		got := db.Cut()
+		AssertErrorIs(t, got, want)
+	})
+}
+
+func TestDBCompact(t *testing.T) {
+	t.Run("Compact removes a Log", func(t *testing.T) {
+		db := testDB(t, nil).(*db)
+
+		// Verify that we start with one Log.
+		got := len(db.logs)
+		AssertEqual(t, got, 1)
+
+		err := db.Cut()
+		AssertNoError(t, err)
+
+		// Verify that we now have two.
+		got = len(db.logs)
+		AssertEqual(t, got, 2)
+
+		// Compaction should bring that back to one.
+		err = db.Compact()
+		AssertNoError(t, err)
+
+		got = len(db.logs)
+		AssertEqual(t, got, 1)
+	})
+
+	t.Run("Compact when DB contains just one Log returns ErrInvalidCompaction", func(t *testing.T) {
+		db := testDB(t, nil)
+
+		err := db.Compact()
+		AssertErrorIs(t, err, ErrInvalidCompaction)
+	})
+
+	t.Run("Compact calls CompactHook", func(t *testing.T) {
+		db := testDB(t, nil)
+
+		called := false
+		db.CompactHook(func(c Counters) error {
+			called = true
+			return nil
+		})
+
+		err := db.Cut()
+		AssertNoError(t, err)
+
+		err = db.Compact()
+		AssertNoError(t, err)
+
+		AssertEqual(t, called, true)
+	})
+
+	t.Run("Error in CompactHook is bubbled up to Compact", func(t *testing.T) {
+		db := testDB(t, nil)
+
+		want := errors.New("error when calling CompactHook")
+		db.CompactHook(func(c Counters) error {
+			return want
+		})
+
+		err := db.Cut()
+		AssertNoError(t, err)
+
+		got := db.Compact()
+		AssertErrorIs(t, got, want)
 	})
 }
 


### PR DESCRIPTION
Adds Cut and Compact methods for manually triggering cuts and compacts. Mostly useful for tests, or for when applications need more control.

Relates to #81 