### PR TITLE
Fix bug with opening existing `logdeck.DB`

### DIFF
--- a/cluster/raft/logdeck/db.go
+++ b/cluster/raft/logdeck/db.go
@@ -193,6 +193,8 @@ func Open(dir string, opts *Options) (DB, error) {
 		}
 	}
 
+	db.offset = uint64(db.logs[0].ID)
+
 	return &db, nil
 }
 

--- a/cluster/raft/logdeck/db.go
+++ b/cluster/raft/logdeck/db.go
@@ -58,6 +58,8 @@ type (
 		// writes to it are flushed to disk. DB only syncs automatically when a Log
 		// is cut and becomes read-noly. Any more syncs are the application's responsibility.
 		Sync() error
+		// Close closes the DB, flushing any pending writes to disk.
+		Close() error
 	}
 
 	// Type represents the type of a value appended to the DB. Consumers of DB
@@ -112,7 +114,7 @@ var DefaultOptions = &Options{
 // Logs belonging to a DB, the DB reads the Logs to restore its in-memory state.
 func Open(dir string, opts *Options) (DB, error) {
 	db := db{
-		logs: make([]*managedLog, 0),
+		logs: make([]*logFile, 0),
 
 		dir: dir,
 
@@ -176,7 +178,7 @@ func Open(dir string, opts *Options) (DB, error) {
 			return nil, err
 		}
 
-		db.logs = append(db.logs, &managedLog{
+		db.logs = append(db.logs, &logFile{
 			ID:   LogID(id),
 			File: w,
 			log:  newLog(r, w),
@@ -196,7 +198,7 @@ func Open(dir string, opts *Options) (DB, error) {
 
 // db implements the DB interface.
 type db struct {
-	logs []*managedLog
+	logs []*logFile
 	// dir is the directory where the Logs are stored on-disk.
 	dir string
 	// sequence holds the ID of the last log created.
@@ -258,13 +260,13 @@ func (d *db) Append(t Type, value []byte) error {
 	return nil
 }
 
-func (d *db) appendWouldExceedLimits(log *managedLog, r *record) bool {
+func (d *db) appendWouldExceedLimits(log *logFile, r *record) bool {
 	return d.maxLogSize < log.cursor+r.size() ||
 		uint64(d.maxLogRecordCount) <= log.counters.total()
 }
 
 func (d *db) Sync() error {
-	return d.activeLog().sync()
+	return d.activeLog().Sync()
 }
 
 func (d *db) Get(t Type, i int) ([]byte, error) {
@@ -352,14 +354,19 @@ func (d *db) CompactHook(h CompactHookFunc) {
 	d.compactHook = h
 }
 
-func (d *db) activeLog() *managedLog {
+func (d *db) Close() error {
+	// TODO: Should also close other logs.
+	return d.activeLog().Close()
+}
+
+func (d *db) activeLog() *logFile {
 	return d.logs[len(d.logs)-1]
 }
 
-func (d *db) newLog() (*managedLog, error) {
-	logFile := filepath.Join(d.dir, fmt.Sprintf("%020d.log", d.sequence))
+func (d *db) newLog() (*logFile, error) {
+	filename := filepath.Join(d.dir, fmt.Sprintf("%020d.log", d.sequence))
 
-	w, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY, 0644)
+	w, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return nil, err
 	}
@@ -368,12 +375,12 @@ func (d *db) newLog() (*managedLog, error) {
 		return nil, err
 	}
 
-	r, err := mmap.Open(logFile)
+	r, err := mmap.Open(filename)
 	if err != nil {
 		return nil, err
 	}
 
-	log := &managedLog{
+	log := &logFile{
 		log:  newLog(r, w),
 		ID:   LogID(d.sequence),
 		File: w,
@@ -386,9 +393,9 @@ func (d *db) newLog() (*managedLog, error) {
 	return log, nil
 }
 
-func (d *db) cut() (*managedLog, error) {
+func (d *db) cut() (*logFile, error) {
 	oldLog := d.activeLog()
-	err := oldLog.sync()
+	err := oldLog.Sync()
 	if err != nil {
 		return nil, err
 	}
@@ -408,14 +415,12 @@ func (d *db) cut() (*managedLog, error) {
 	return newLog, nil
 }
 
-// TODO: Should close Log's file descriptors here...?
 func (d *db) compact() error {
 	if len(d.logs) <= 1 {
 		return fmt.Errorf("%w: only one Log in DB", ErrInvalidCompaction)
 	}
 
 	log := d.logs[0]
-	id := log.ID
 
 	// The CompactHook is run _before_ compaction actually occurs
 	// so that the Deck consumer has a full view of the data, including
@@ -428,9 +433,11 @@ func (d *db) compact() error {
 		}
 	}
 
-	logFile := filepath.Join(d.dir, fmt.Sprintf("%020d.log", id))
-	err := os.Remove(logFile)
-	if err != nil {
+	if err := log.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Remove(log.File.Name()); err != nil {
 		return err
 	}
 
@@ -456,18 +463,32 @@ func (d *db) pointer() pointer {
 
 var logNameRe = regexp.MustCompile(`(\d{20}).log`)
 
-// managedLog represents a Log that is managed by DB.
+// logFile represents a Log that is backed by a file.
 // It wraps the basic Log and adds an ID for tracking unique Logs,
 // and the handles of the underlying file.
-type managedLog struct {
+type logFile struct {
 	*log
 	ID   LogID
 	File *os.File
 	Mmap *mmap.ReaderAt
 }
 
-func (l *managedLog) sync() error {
+func (l *logFile) Sync() error {
 	return syscall.Fdatasync(int(l.File.Fd()))
+}
+
+func (l *logFile) Close() error {
+	err := l.Sync()
+	if err != nil {
+		return err
+	}
+
+	err = l.File.Close()
+	if err != nil {
+		return err
+	}
+
+	return l.Mmap.Close()
 }
 
 func discoverLogFiles(dir string) ([]string, error) {

--- a/cluster/raft/logdeck/db_test.go
+++ b/cluster/raft/logdeck/db_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestDBAppend(t *testing.T) {
 	t.Run("Appended values are retrievable", func(t *testing.T) {
-		db := testDB(t, nil)
+		db := testDB(t, t.TempDir(), nil)
 
 		wantType := randomType()
 		wantValues := RandomBytesN(5, 16, 32)
@@ -39,7 +39,7 @@ func TestDBAppend(t *testing.T) {
 	})
 
 	t.Run("Append triggers Cut when MaxLogSize exceeded", func(t *testing.T) {
-		db := testDB(t, &Options{
+		db := testDB(t, t.TempDir(), &Options{
 			MaxLogSize: 64,
 		})
 
@@ -58,7 +58,7 @@ func TestDBAppend(t *testing.T) {
 	})
 
 	t.Run("Append triggers Cut when MaxLogRecordCount exceeded", func(t *testing.T) {
-		db := testDB(t, &Options{
+		db := testDB(t, t.TempDir(), &Options{
 			MaxLogValueCount: 1,
 		})
 
@@ -77,7 +77,7 @@ func TestDBAppend(t *testing.T) {
 	})
 
 	t.Run("Append triggers Compact when MaxLogCount exceeded", func(t *testing.T) {
-		db := testDB(t, &Options{
+		db := testDB(t, t.TempDir(), &Options{
 			MaxLogValueCount: 1,
 			MaxLogCount:      1,
 		})
@@ -98,7 +98,7 @@ func TestDBAppend(t *testing.T) {
 }
 
 func TestDBGet(t *testing.T) {
-	db := testDB(t, nil)
+	db := testDB(t, t.TempDir(), nil)
 
 	wantType, wantValue := randomType(), RandomBytes(32)
 
@@ -124,7 +124,7 @@ func TestDBGet(t *testing.T) {
 
 func TestDBCut(t *testing.T) {
 	t.Run("Cut provisions a new Log every time it is called", func(t *testing.T) {
-		db := testDB(t, nil).(*db)
+		db := testDB(t, t.TempDir(), nil).(*db)
 
 		target := 5
 
@@ -139,7 +139,7 @@ func TestDBCut(t *testing.T) {
 	})
 
 	t.Run("Cut calls CutHook", func(t *testing.T) {
-		db := testDB(t, nil)
+		db := testDB(t, t.TempDir(), nil)
 
 		want := true
 		got := false
@@ -154,7 +154,7 @@ func TestDBCut(t *testing.T) {
 	})
 
 	t.Run("LogID is passed to CutHook and incremented correctly", func(t *testing.T) {
-		db := testDB(t, nil)
+		db := testDB(t, t.TempDir(), nil)
 
 		var got LogID
 		db.CutHook(func(id LogID) error {
@@ -170,7 +170,7 @@ func TestDBCut(t *testing.T) {
 	})
 
 	t.Run("Error from CutHook is bubbled up to Cut", func(t *testing.T) {
-		db := testDB(t, nil)
+		db := testDB(t, t.TempDir(), nil)
 
 		want := errors.New("error when calling CutHook")
 		db.CutHook(func(id LogID) error {
@@ -185,7 +185,7 @@ func TestDBCut(t *testing.T) {
 
 func TestDBCompact(t *testing.T) {
 	t.Run("Compact removes a Log", func(t *testing.T) {
-		db := testDB(t, nil).(*db)
+		db := testDB(t, t.TempDir(), nil).(*db)
 
 		// Verify that we start with one Log.
 		got := len(db.logs)
@@ -207,14 +207,14 @@ func TestDBCompact(t *testing.T) {
 	})
 
 	t.Run("Compact when DB contains just one Log returns ErrInvalidCompaction", func(t *testing.T) {
-		db := testDB(t, nil)
+		db := testDB(t, t.TempDir(), nil)
 
 		err := db.Compact()
 		AssertErrorIs(t, err, ErrInvalidCompaction)
 	})
 
 	t.Run("Compact calls CompactHook", func(t *testing.T) {
-		db := testDB(t, nil)
+		db := testDB(t, t.TempDir(), nil)
 
 		called := false
 		db.CompactHook(func(c Counters) error {
@@ -232,7 +232,7 @@ func TestDBCompact(t *testing.T) {
 	})
 
 	t.Run("Error in CompactHook is bubbled up to Compact", func(t *testing.T) {
-		db := testDB(t, nil)
+		db := testDB(t, t.TempDir(), nil)
 
 		want := errors.New("error when calling CompactHook")
 		db.CompactHook(func(c Counters) error {
@@ -248,8 +248,40 @@ func TestDBCompact(t *testing.T) {
 	})
 }
 
-func testDB(t *testing.T, opts *Options) DB {
+func TestDBOpenExisting(t *testing.T) {
 	dir := t.TempDir()
+	db := testDB(t, dir, &Options{
+		MaxLogCount: 8,
+	})
+
+	// Generate a bunch of random values, appending each to the DB.
+	// We call Cut after every Append, because we want to create
+	// a lot of Log files. We also need to trigger at least a few
+	// compactions, so we should append more values than MaxLogCount.
+	wantType := randomType()
+	wantValues := RandomBytesN(16, 1<<10, 10<<10)
+	for _, value := range wantValues {
+		err := db.Append(wantType, value)
+		AssertNoError(t, err).Require()
+		err = db.Cut()
+		AssertNoError(t, err).Require()
+	}
+
+	err := db.Close()
+	AssertNoError(t, err).Require()
+
+	// Open a new DB in the same directory.
+	db = testDB(t, dir, nil)
+
+	// Read all log files.
+	db.ReadAll()
+
+	got, err := db.Last(wantType)
+	AssertNoError(t, err).Require()
+	AssertSlicesEqual(t, got, wantValues[len(wantValues)-1])
+}
+
+func testDB(t *testing.T, dir string, opts *Options) DB {
 	t.Cleanup(func() {
 		os.RemoveAll(dir) // nolint: errcheck
 	})

--- a/cluster/raft/logdeck/log.go
+++ b/cluster/raft/logdeck/log.go
@@ -72,12 +72,6 @@ func (l *log) Pointer() (int64, int64) {
 	return l.pointer + RecordHeaderLength, l.lastValueSize
 }
 
-// Also get rid of this. It's only used in a test, and never intended to be used in production.
-func (l *log) Rewind() {
-	l.cursor = 0
-	l.pointer = 0
-}
-
 func (l *log) advance(n int64, t Type) {
 	l.pointer = l.cursor
 	l.cursor += n

--- a/cluster/raft/logdeck/log_test.go
+++ b/cluster/raft/logdeck/log_test.go
@@ -35,21 +35,23 @@ func tempLog(t *testing.T) (io.ReaderAt, io.Writer) {
 
 func TestLogReadAll(t *testing.T) {
 	want := randomRecordsN(10, 16, 32)
+	r, w := tempLog(t)
 
-	l := newLog(tempLog(t))
+	l := newLog(r, w)
 
 	for i := range want {
 		err := l.Append(want[i])
 		AssertNoError(t, err).Require()
 	}
 
-	l.Rewind()
+	l = newLog(r, w)
 
 	i := 0
 	for got := range l.All() {
 		AssertDeepEqual(t, got, want[i])
 		i++
 	}
+	AssertEqual(t, i, len(want))
 }
 
 // The decoder normally keeps reading until EOF.

--- a/cluster/raft/node.go
+++ b/cluster/raft/node.go
@@ -46,6 +46,11 @@ func NewNode(id uint64, addr netip.AddrPort, peers []Peer, workDir string, snap 
 	}
 
 	conf := raft.Config{
+		// TODO: This may need to be set when restarting a node.
+		// But I'm not sure of how to persist it. It can only be saved _after_
+		// applying entries to the state machine. And etcd doesn't seem to set this either.
+		Applied: 0,
+
 		ID:                id,
 		ElectionTick:      10,
 		HeartbeatTick:     1,

--- a/cluster/raft/node.go
+++ b/cluster/raft/node.go
@@ -17,7 +17,7 @@ type (
 	Node interface { // Represents everything that a Raft node has to do for Raft to work
 		// Lifecycle
 		Start()
-		Stop()
+		Stop() error
 		Tick()
 		ClusterStatus() Status
 
@@ -102,7 +102,9 @@ func (n *node) Start() {
 	go n.mesh.Start()
 }
 
-func (n *node) Stop() {}
+func (n *node) Stop() error {
+	return n.storage.deck.Close()
+}
 
 func (n *node) Tick() {
 	n.manualTick <- time.Now()

--- a/cluster/raft/storage.go
+++ b/cluster/raft/storage.go
@@ -28,13 +28,13 @@ func NewDiskStorage(deck logdeck.DB, snap cluster.Snapshotter) (*DiskStorage, er
 	if s.deck.Count(TypeEntry) > 0 {
 		value, err := s.deck.First(TypeEntry)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to read first entry: %w", err)
 		}
 
 		var entry raftpb.Entry
 		err = entry.Unmarshal(value)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to unmarshal first entry: %w", err)
 		}
 
 		s.firstEntry = raftpb.Entry{

--- a/cluster/raft/storage.go
+++ b/cluster/raft/storage.go
@@ -3,6 +3,7 @@ package raft
 import (
 	"bytes"
 	"fmt"
+	"log"
 
 	"github.com/robinkb/cascade-registry/cluster"
 	"github.com/robinkb/cascade-registry/cluster/raft/logdeck"
@@ -26,6 +27,7 @@ func NewDiskStorage(deck logdeck.DB, snap cluster.Snapshotter) (*DiskStorage, er
 	s.deck.ReadAll()
 
 	if s.deck.Count(TypeEntry) > 0 {
+		log.Println("count", s.deck.Count(TypeEntry))
 		value, err := s.deck.First(TypeEntry)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read first entry: %w", err)
@@ -84,7 +86,6 @@ func NewDiskStorage(deck logdeck.DB, snap cluster.Snapshotter) (*DiskStorage, er
 	// 	}
 	// }()
 
-	// TODO: cutHook is broken.
 	s.deck.CutHook(s.cutHook())
 	s.deck.CompactHook(s.compactionHook())
 

--- a/cmd/cascade-registry/main.go
+++ b/cmd/cascade-registry/main.go
@@ -63,6 +63,7 @@ func main() {
 		metadata = cluster.NewMetadataStore(node, metadata)
 		blobs = cluster.NewBlobStore(node, blobs)
 		node.Start()
+		defer node.Stop()
 	}
 
 	service := cascade.NewRegistryService(metadata, blobs)

--- a/cmd/cascade-registry/main.go
+++ b/cmd/cascade-registry/main.go
@@ -63,7 +63,11 @@ func main() {
 		metadata = cluster.NewMetadataStore(node, metadata)
 		blobs = cluster.NewBlobStore(node, blobs)
 		node.Start()
-		defer node.Stop()
+		defer func() {
+			if err := node.Stop(); err != nil {
+				log.Println("error while stopping Raft node:", err)
+			}
+		}()
 	}
 
 	service := cascade.NewRegistryService(metadata, blobs)

--- a/testing/mock/raft_node.go
+++ b/testing/mock/raft_node.go
@@ -264,9 +264,20 @@ func (_c *RaftNode_Start_Call) RunAndReturn(run func()) *RaftNode_Start_Call {
 }
 
 // Stop provides a mock function for the type RaftNode
-func (_mock *RaftNode) Stop() {
-	_mock.Called()
-	return
+func (_mock *RaftNode) Stop() error {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Stop")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func() error); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
 }
 
 // RaftNode_Stop_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Stop'
@@ -286,13 +297,13 @@ func (_c *RaftNode_Stop_Call) Run(run func()) *RaftNode_Stop_Call {
 	return _c
 }
 
-func (_c *RaftNode_Stop_Call) Return() *RaftNode_Stop_Call {
-	_c.Call.Return()
+func (_c *RaftNode_Stop_Call) Return(err error) *RaftNode_Stop_Call {
+	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *RaftNode_Stop_Call) RunAndReturn(run func()) *RaftNode_Stop_Call {
-	_c.Run(run)
+func (_c *RaftNode_Stop_Call) RunAndReturn(run func() error) *RaftNode_Stop_Call {
+	_c.Call.Return(run)
 	return _c
 }
 


### PR DESCRIPTION
When stopping and restarting a node, it would often fail to read data from the Raft log backed by `logdeck.DB`. Turns out that `logdeck.DB`'s state was not properly restored from disk when the Log IDs do not start from 0, like after compaction.

Added a test to reproduce it, and then fixed the bug.

There's also some changes here about closing Log files, but that was done in service of tracking down the bug. #74 will be resolved in a separate PR.