### PR TITLE
Properly manage file handlers in logdeck.DB

### DIFF
--- a/cluster/raft/logdeck/db.go
+++ b/cluster/raft/logdeck/db.go
@@ -6,108 +6,7 @@ import (
 	"iter"
 	"os"
 	"path/filepath"
-	"regexp"
-	"slices"
-	"strconv"
-	"syscall"
-
-	"golang.org/x/exp/mmap"
 )
-
-type (
-	// DB represents a sequential collection of values, organized into Logs,
-	// and indexed by type and sequence. New values are appended to the active Log.
-	// Once the active Log reaches MaxLogSize, a new Log is provisioned to
-	// receive new appends. The old Log becomes read-only. Once DB exceeds
-	// MaxLogCount, compaction removes the oldest Log and its values.
-	DB interface {
-		// Append writes a value to the DB.
-		Append(t Type, value []byte) error
-		// Get retrieves a value with Type t at index i.
-		Get(t Type, i int) ([]byte, error)
-		// Count returns how many values with Type t are in DB.
-		Count(t Type) int
-		// First returns the first value of Type t in the DB. The value returned
-		// by this method changes after a compaction.
-		First(t Type) ([]byte, error)
-		// Last returns the last value of Type t that was written to the DB.
-		Last(t Type) ([]byte, error)
-		// Range returns an iterator that ranges over all values of Type t
-		// in the range [lo, hi[.
-		Range(t Type, lo, hi int) iter.Seq2[[]byte, error]
-		// Cut manually cuts a new Log in the DB. Cutting a Log is normally
-		// triggered automatically when MaxLogSize or MaxLogRecordCount is
-		// exceeded. Instead, Cut may be used to trigger them manually when more
-		// control is required, like for tests. As such, Cut does not consider
-		// MaxLogSize and MaxLogRecordCount.
-		Cut() error
-		// Compact manually triggers a compaction. Compactions are normally
-		// triggered automatically when MaxLogCount is exceeded. Instead,
-		// Compact may be used to trigger them manually when more control
-		// is required, like for tests. As such, Compact does not consider MaxLogCount.
-		// Attempting to Compact when the DB only contains one Log returns ErrInvalidCompaction.
-		Compact() error
-		// CutHook registers CutHookFunc f, which is run whenever a Log is cut.
-		// To clear the CutHook, call CutHook with a nil argument.
-		CutHook(f CutHookFunc)
-		// CompactHook registers CompactHook f, which is run whenever DB compacts a Log.
-		// To clear the CompactHook, call CompactHook with a nil argument.
-		CompactHook(f CompactHookFunc)
-		// Sync calls syscall.Fdatasync on the active Log, ensuring that buffered
-		// writes to it are flushed to disk. DB only syncs automatically when a Log
-		// is cut and becomes read-noly. Any more syncs are the application's responsibility.
-		Sync() error
-		// Close closes the DB, flushing any pending writes to disk.
-		Close() error
-	}
-
-	// Type represents the type of a value appended to the DB. Consumers of DB
-	// are expected to define their own types as constants of Type.
-	Type uint32
-
-	// LogID represents the sequential ID of a Log in the DB.
-	LogID uint64
-
-	// CutHookFunc is executed whenever a Log is cut. A Log is cut when it reaches
-	// its maximum size and is moved into read-only mode. A new Log is then
-	// provisioned to receive new writes. CutHookFunc is executed right after
-	// the new Log is provisioned. If Append is called on the LogDeck in
-	// CutHookFunc, the appended value is guaranteed to be the first in the new Log.
-	CutHookFunc func(id LogID) error
-
-	// CompactHookFunc is executed whenever a Log is compacted. Compaction is
-	// triggered when a newly provisioned Log causes MaxLogCount to be exceeded.
-	// CompactionHookFunc is executed right before the oldest Log is actually
-	// removed from DB, meaning that its data can still be queried for the
-	// duration of CompactHookFunc.
-	// TODO: Instead of Counters, maybe have it be an iter.Seq2[Type, uint64],
-	// the signature of Counters.All(). That way we can make Counters private.
-	CompactHookFunc func(c Counters) error
-
-	// Options defines the configurable options of the DB.
-	Options struct {
-		// MaxLogSize determines the maximum size that a single Log in the DB can have.
-		// When appending a value to a Log would make it grow larger than MaxLogSize,
-		// a new Log is provisioned, and the value is appended to the new Log.
-		// The total maximum DB size on disk is MaxLogSize * (MaxLogCount + 1).
-		MaxLogSize int64
-		// MaxLogValueCount determines the maximum amount of values that a single Log in the DB can have.
-		// When appending a value to a Log would make it exceed MaxLogValueCount,
-		// a new Log is provisioned, and the value is appended to the new Log.
-		MaxLogValueCount int64
-		// MaxLogCount determines how many Logs can be contained in the DB.
-		// Once exceeded, the oldest Log in the DB is compacted.
-		// The total maximum DB size on disk is MaxLogSize * (MaxLogCount + 1).
-		MaxLogCount int
-	}
-)
-
-// DefaultOptions defines the default Options values.
-var DefaultOptions = &Options{
-	MaxLogSize:       64 << 20,
-	MaxLogValueCount: 10000,
-	MaxLogCount:      16,
-}
 
 // Open intializes a DB in directory dir. If the directory already contains
 // Logs belonging to a DB, the DB reads the Logs to restore its in-memory state.
@@ -218,18 +117,18 @@ type db struct {
 	// If a Record will cause a Log to exceed its maximum allowed size,
 	// a new Log will be provisioned and the Record will be appended there.
 	maxLogRecordCount int64
-	// maxLogCount determines the maximum amount of logs stored in the Deck.
+	// maxLogCount determines the maximum amount of logs stored in the DB.
 	// When the number of logs exceeds this number, the oldest log will be compacted.
 	maxLogCount int
-	// Inventory holds pointers to all known Records in the Deck,
-	// organized by type. It grows when appending Records to the Deck,
-	// and shrinks when Logs in the Deck are compacted.
+	// Inventory holds pointers to all known Records in the DB,
+	// organized by type. It grows when appending Records to the DB,
+	// and shrinks when Logs in the DB are compacted.
 	inventory *inventory
-	// cutHook is provided by the Deck consumer. If provided,
-	// it is called by Deck after every Log is cut.
+	// cutHook is provided by the DB consumer. If provided,
+	// it is called by DB after every Log is cut.
 	cutHook CutHookFunc
-	// compactHook is provided by the Deck consumer. If provided,
-	// it is called by Deck after every compaction, allowing the consumer
+	// compactHook is provided by the DB consumer. If provided,
+	// it is called by DB after every compaction, allowing the consumer
 	// to update its internal bookkeeping.
 	compactHook CompactHookFunc
 }
@@ -257,7 +156,7 @@ func (d *db) Append(t Type, value []byte) error {
 	d.inventory.Add(r.Type, d.pointer())
 
 	// Run compaction _after_ adding the new entry so that
-	// the compaction handler has an up-to-date view of the Deck.
+	// the compaction handler has an up-to-date view of the DB.
 	if len(d.logs) > d.maxLogCount {
 		return d.compact()
 	}
@@ -404,7 +303,7 @@ func (d *db) compact() error {
 	log := d.logs[0]
 
 	// The CompactHook is run _before_ compaction actually occurs
-	// so that the Deck consumer has a full view of the data, including
+	// so that the DB consumer has a full view of the data, including
 	// what is being removed. An errors encountered by compaction are surfaced
 	// to the application.
 	if d.compactHook != nil {
@@ -440,114 +339,4 @@ func (d *db) pointer() pointer {
 		Offset: offset,
 		Size:   size,
 	}
-}
-
-func createLogFile(dir string, id LogID, size int64) (*logFile, error) {
-	filename := filepath.Join(dir, fmt.Sprintf("%020d.log", id))
-
-	w, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return nil, err
-	}
-	err = syscall.Fallocate(int(w.Fd()), 0, 0, size)
-	if err != nil {
-		return nil, err
-	}
-
-	r, err := mmap.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-
-	return &logFile{
-		ID:   id,
-		File: w,
-		Mmap: r,
-		log:  newLog(r, w),
-	}, nil
-}
-
-func openLogFile(filename string) (*logFile, error) {
-	basename := filepath.Base(filename)
-	id, err := strconv.ParseUint(basename[:len(basename)-4], 10, 64)
-	if err != nil {
-		return nil, err
-	}
-
-	w, err := os.OpenFile(filename, os.O_WRONLY, 0644)
-	if err != nil {
-		return nil, err
-	}
-
-	r, err := mmap.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-
-	return &logFile{
-		ID:   LogID(id),
-		File: w,
-		Mmap: r,
-		log:  newLog(r, w),
-	}, nil
-}
-
-// logFile represents a Log that is backed by a file.
-// It wraps the basic Log and adds an ID for tracking unique Logs,
-// and the handles of the underlying file.
-type logFile struct {
-	*log
-	ID   LogID
-	File *os.File
-	Mmap *mmap.ReaderAt
-}
-
-func (l *logFile) Sync() error {
-	return syscall.Fdatasync(int(l.File.Fd()))
-}
-
-func (l *logFile) Lock() error {
-	if err := l.Sync(); err != nil {
-		return err
-	}
-
-	if err := os.Truncate(l.File.Name(), l.cursor); err != nil {
-		return err
-	}
-
-	return l.File.Close()
-}
-
-func (l *logFile) Close() error {
-	if err := l.File.Close(); err != nil {
-		if !errors.Is(err, os.ErrClosed) {
-			return err
-		}
-	}
-	return l.Mmap.Close()
-}
-
-var logNameRe = regexp.MustCompile(`(\d{20}).log`)
-
-// discoverLogFiles searches for files with names matching logNameRe in directory dir,
-// returning a sorted list of filenames.
-func discoverLogFiles(dir string) ([]string, error) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil, err
-	}
-
-	logFiles := make([]string, 0)
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-
-		if logNameRe.MatchString(e.Name()) {
-			logFiles = append(logFiles, e.Name())
-		}
-	}
-
-	slices.Sort(logFiles)
-	return logFiles, nil
 }

--- a/cluster/raft/logdeck/db.go
+++ b/cluster/raft/logdeck/db.go
@@ -162,27 +162,13 @@ func Open(dir string, opts *Options) (DB, error) {
 	}
 
 	for _, name := range logFiles {
-		id, err := strconv.ParseUint(name[:len(name)-4], 10, 64)
-		if err != nil {
-			return nil, err
-		}
-
 		name := filepath.Join(db.dir, name)
-		w, err := os.OpenFile(name, os.O_WRONLY, 0644)
+		log, err := openLogFile(name)
 		if err != nil {
 			return nil, err
 		}
 
-		r, err := mmap.Open(name)
-		if err != nil {
-			return nil, err
-		}
-
-		db.logs = append(db.logs, &logFile{
-			ID:   LogID(id),
-			File: w,
-			log:  newLog(r, w),
-		})
+		db.logs = append(db.logs, log)
 		db.sequence++
 	}
 
@@ -464,6 +450,31 @@ func (d *db) pointer() pointer {
 }
 
 var logNameRe = regexp.MustCompile(`(\d{20}).log`)
+
+func openLogFile(filename string) (*logFile, error) {
+	basename := filepath.Base(filename)
+	id, err := strconv.ParseUint(basename[:len(basename)-4], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	w, err := os.OpenFile(filename, os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := mmap.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return &logFile{
+		ID:   LogID(id),
+		File: w,
+		// Mmap: r,
+		log: newLog(r, w),
+	}, nil
+}
 
 // logFile represents a Log that is backed by a file.
 // It wraps the basic Log and adds an ID for tracking unique Logs,

--- a/cluster/raft/logdeck/db.go
+++ b/cluster/raft/logdeck/db.go
@@ -160,7 +160,7 @@ func Open(dir string, opts *Options) (DB, error) {
 		return nil, err
 	}
 
-	for _, name := range logFiles {
+	for i, name := range logFiles {
 		name := filepath.Join(db.dir, name)
 		log, err := openLogFile(name)
 		if err != nil {
@@ -176,6 +176,13 @@ func Open(dir string, opts *Options) (DB, error) {
 				Offset: offset,
 				Size:   size,
 			})
+		}
+
+		// Lock all but the last log file.
+		if i != len(logFiles)-1 {
+			if err := log.Lock(); err != nil {
+				return nil, err
+			}
 		}
 
 		db.logs = append(db.logs, log)
@@ -339,7 +346,15 @@ func (d *db) CompactHook(h CompactHookFunc) {
 }
 
 func (d *db) Close() error {
-	// TODO: Should also close other logs.
+	for _, log := range d.logs[:len(d.logs)-1] {
+		if err := log.Close(); err != nil {
+			return err
+		}
+	}
+	if err := d.activeLog().Sync(); err != nil {
+		return err
+	}
+
 	return d.activeLog().Close()
 }
 
@@ -361,7 +376,7 @@ func (d *db) newLog() (*logFile, error) {
 
 func (d *db) cut() (*logFile, error) {
 	oldLog := d.activeLog()
-	err := oldLog.Sync()
+	err := oldLog.Lock()
 	if err != nil {
 		return nil, err
 	}
@@ -491,17 +506,24 @@ func (l *logFile) Sync() error {
 	return syscall.Fdatasync(int(l.File.Fd()))
 }
 
+func (l *logFile) Lock() error {
+	if err := l.Sync(); err != nil {
+		return err
+	}
+
+	if err := os.Truncate(l.File.Name(), l.log.cursor); err != nil {
+		return err
+	}
+
+	return l.File.Close()
+}
+
 func (l *logFile) Close() error {
-	err := l.Sync()
-	if err != nil {
-		return err
+	if err := l.File.Close(); err != nil {
+		if !errors.Is(err, os.ErrClosed) {
+			return err
+		}
 	}
-
-	err = l.File.Close()
-	if err != nil {
-		return err
-	}
-
 	return l.Mmap.Close()
 }
 

--- a/cluster/raft/logdeck/db.go
+++ b/cluster/raft/logdeck/db.go
@@ -352,30 +352,12 @@ func (d *db) activeLog() *logFile {
 }
 
 func (d *db) newLog() (*logFile, error) {
-	filename := filepath.Join(d.dir, fmt.Sprintf("%020d.log", d.sequence))
-
-	w, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return nil, err
-	}
-	err = syscall.Fallocate(int(w.Fd()), 0, 0, d.maxLogSize)
+	log, err := createLogFile(d.dir, LogID(d.sequence), d.maxLogSize)
 	if err != nil {
 		return nil, err
 	}
 
-	r, err := mmap.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-
-	log := &logFile{
-		log:  newLog(r, w),
-		ID:   LogID(d.sequence),
-		File: w,
-		Mmap: r,
-	}
 	d.logs = append(d.logs, log)
-
 	d.sequence++
 
 	return log, nil
@@ -451,6 +433,31 @@ func (d *db) pointer() pointer {
 
 var logNameRe = regexp.MustCompile(`(\d{20}).log`)
 
+func createLogFile(dir string, id LogID, size int64) (*logFile, error) {
+	filename := filepath.Join(dir, fmt.Sprintf("%020d.log", id))
+
+	w, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+	err = syscall.Fallocate(int(w.Fd()), 0, 0, size)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := mmap.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return &logFile{
+		ID:   id,
+		File: w,
+		Mmap: r,
+		log:  newLog(r, w),
+	}, nil
+}
+
 func openLogFile(filename string) (*logFile, error) {
 	basename := filepath.Base(filename)
 	id, err := strconv.ParseUint(basename[:len(basename)-4], 10, 64)
@@ -471,8 +478,8 @@ func openLogFile(filename string) (*logFile, error) {
 	return &logFile{
 		ID:   LogID(id),
 		File: w,
-		// Mmap: r,
-		log: newLog(r, w),
+		Mmap: r,
+		log:  newLog(r, w),
 	}, nil
 }
 

--- a/cluster/raft/logdeck/db.go
+++ b/cluster/raft/logdeck/db.go
@@ -511,7 +511,7 @@ func (l *logFile) Lock() error {
 		return err
 	}
 
-	if err := os.Truncate(l.File.Name(), l.log.cursor); err != nil {
+	if err := os.Truncate(l.File.Name(), l.cursor); err != nil {
 		return err
 	}
 

--- a/cluster/raft/logdeck/db.go
+++ b/cluster/raft/logdeck/db.go
@@ -53,7 +53,6 @@ type (
 		// CompactHook registers CompactHook f, which is run whenever DB compacts a Log.
 		// To clear the CompactHook, call CompactHook with a nil argument.
 		CompactHook(f CompactHookFunc)
-		ReadAll()
 		// Sync calls syscall.Fdatasync on the active Log, ensuring that buffered
 		// writes to it are flushed to disk. DB only syncs automatically when a Log
 		// is cut and becomes read-noly. Any more syncs are the application's responsibility.
@@ -166,6 +165,17 @@ func Open(dir string, opts *Options) (DB, error) {
 		log, err := openLogFile(name)
 		if err != nil {
 			return nil, err
+		}
+
+		// Read the entire log to rebuild our in-memory inventory of records.
+		for record := range log.All() {
+			offset, size := log.Pointer()
+
+			db.inventory.Add(record.Type, pointer{
+				Log:    log.ID,
+				Offset: offset,
+				Size:   size,
+			})
 		}
 
 		db.logs = append(db.logs, log)
@@ -311,20 +321,6 @@ func (d *db) valueAt(p pointer) ([]byte, error) {
 	return value, err
 }
 
-func (d *db) ReadAll() {
-	for _, log := range d.logs {
-		for record := range log.All() {
-			offset, size := log.Pointer()
-
-			d.inventory.Add(record.Type, pointer{
-				Log:    log.ID,
-				Offset: offset,
-				Size:   size,
-			})
-		}
-	}
-}
-
 func (d *db) Cut() error {
 	_, err := d.cut()
 	return err
@@ -431,8 +427,6 @@ func (d *db) pointer() pointer {
 	}
 }
 
-var logNameRe = regexp.MustCompile(`(\d{20}).log`)
-
 func createLogFile(dir string, id LogID, size int64) (*logFile, error) {
 	filename := filepath.Join(dir, fmt.Sprintf("%020d.log", id))
 
@@ -511,6 +505,10 @@ func (l *logFile) Close() error {
 	return l.Mmap.Close()
 }
 
+var logNameRe = regexp.MustCompile(`(\d{20}).log`)
+
+// discoverLogFiles searches for files with names matching logNameRe in directory dir,
+// returning a sorted list of filenames.
 func discoverLogFiles(dir string) ([]string, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {

--- a/cluster/raft/logdeck/db_test.go
+++ b/cluster/raft/logdeck/db_test.go
@@ -273,9 +273,6 @@ func TestDBOpenExisting(t *testing.T) {
 	// Open a new DB in the same directory.
 	db = testDB(t, dir, nil)
 
-	// Read all log files.
-	db.ReadAll()
-
 	got, err := db.Last(wantType)
 	AssertNoError(t, err).Require()
 	AssertSlicesEqual(t, got, wantValues[len(wantValues)-1])

--- a/cluster/raft/logdeck/example_test.go
+++ b/cluster/raft/logdeck/example_test.go
@@ -13,11 +13,14 @@ const (
 
 func Example() {
 	// Open the DB.
-	dir := os.TempDir()
+	dir, _ := os.MkdirTemp(os.TempDir(), "db")
+	defer os.RemoveAll(dir) // nolint: errcheck
+
 	db, err := Open(dir, nil)
 	if err != nil {
 		panic(err)
 	}
+	defer db.Close() // nolint: errcheck
 
 	// Write some values.
 	db.Append(TypeSetup, []byte("Why did the chicken cross the road?")) // nolint: errcheck

--- a/cluster/raft/logdeck/interface.go
+++ b/cluster/raft/logdeck/interface.go
@@ -1,0 +1,98 @@
+package logdeck
+
+import "iter"
+
+type (
+	// DB represents a sequential collection of values, organized into Logs,
+	// and indexed by type and sequence. New values are appended to the active Log.
+	// Once the active Log reaches MaxLogSize, a new Log is provisioned to
+	// receive new appends. The old Log becomes read-only. Once DB exceeds
+	// MaxLogCount, compaction removes the oldest Log and its values.
+	DB interface {
+		// Append writes a value to the DB.
+		Append(t Type, value []byte) error
+		// Get retrieves a value with Type t at index i.
+		Get(t Type, i int) ([]byte, error)
+		// Count returns how many values with Type t are in DB.
+		Count(t Type) int
+		// First returns the first value of Type t in the DB. The value returned
+		// by this method changes after a compaction.
+		First(t Type) ([]byte, error)
+		// Last returns the last value of Type t that was written to the DB.
+		Last(t Type) ([]byte, error)
+		// Range returns an iterator that ranges over all values of Type t
+		// in the range [lo, hi[.
+		Range(t Type, lo, hi int) iter.Seq2[[]byte, error]
+		// Cut manually cuts a new Log in the DB. Cutting a Log is normally
+		// triggered automatically when MaxLogSize or MaxLogRecordCount is
+		// exceeded. Instead, Cut may be used to trigger them manually when more
+		// control is required, like for tests. As such, Cut does not consider
+		// MaxLogSize and MaxLogRecordCount.
+		Cut() error
+		// Compact manually triggers a compaction. Compactions are normally
+		// triggered automatically when MaxLogCount is exceeded. Instead,
+		// Compact may be used to trigger them manually when more control
+		// is required, like for tests. As such, Compact does not consider MaxLogCount.
+		// Attempting to Compact when the DB only contains one Log returns ErrInvalidCompaction.
+		Compact() error
+		// CutHook registers CutHookFunc f, which is run whenever a Log is cut.
+		// To clear the CutHook, call CutHook with a nil argument.
+		CutHook(f CutHookFunc)
+		// CompactHook registers CompactHook f, which is run whenever DB compacts a Log.
+		// To clear the CompactHook, call CompactHook with a nil argument.
+		CompactHook(f CompactHookFunc)
+		// Sync calls syscall.Fdatasync on the active Log, ensuring that buffered
+		// writes to it are flushed to disk. DB only syncs automatically when a Log
+		// is cut and becomes read-noly. Any more syncs are the application's responsibility.
+		Sync() error
+		// Close closes the DB, flushing any pending writes to disk.
+		Close() error
+	}
+
+	// Type represents the type of a value appended to the DB. Consumers of DB
+	// are expected to define their own types as constants of Type.
+	Type uint32
+
+	// LogID represents the sequential ID of a Log in the DB.
+	LogID uint64
+
+	// CutHookFunc is executed whenever a Log is cut. A Log is cut when it reaches
+	// its maximum size and is moved into read-only mode. A new Log is then
+	// provisioned to receive new writes. CutHookFunc is executed right after
+	// the new Log is provisioned. If Append is called on the DB in
+	// CutHookFunc, the appended value is guaranteed to be the first in the new Log.
+	CutHookFunc func(id LogID) error
+
+	// CompactHookFunc is executed whenever a Log is compacted. Compaction is
+	// triggered when a newly provisioned Log causes MaxLogCount to be exceeded.
+	// CompactionHookFunc is executed right before the oldest Log is actually
+	// removed from DB, meaning that its data can still be queried for the
+	// duration of CompactHookFunc.
+	// TODO: Instead of Counters, maybe have it be an iter.Seq2[Type, uint64],
+	// the signature of Counters.All(). That way we can make Counters private.
+	CompactHookFunc func(c Counters) error
+
+	// Options defines the configurable options of the DB.
+	Options struct {
+		// MaxLogSize determines the maximum size that a single Log in the DB can have.
+		// When appending a value to a Log would make it grow larger than MaxLogSize,
+		// a new Log is provisioned, and the value is appended to the new Log.
+		// The total maximum DB size on disk is MaxLogSize * (MaxLogCount + 1).
+		MaxLogSize int64
+		// MaxLogValueCount determines the maximum amount of values that a single Log in the DB can have.
+		// When appending a value to a Log would make it exceed MaxLogValueCount,
+		// a new Log is provisioned, and the value is appended to the new Log.
+		MaxLogValueCount int64
+		// MaxLogCount determines how many Logs can be contained in the DB.
+		// Once exceeded, the oldest Log in the DB is compacted.
+		// The total maximum DB size on disk is MaxLogSize * (MaxLogCount + 1).
+		MaxLogCount int
+	}
+)
+
+// DefaultOptions defines the default Options values.
+var DefaultOptions = &Options{
+	MaxLogSize:       64 << 20,
+	MaxLogValueCount: 10000,
+	MaxLogCount:      16,
+}

--- a/cluster/raft/logdeck/inventory.go
+++ b/cluster/raft/logdeck/inventory.go
@@ -79,8 +79,8 @@ func (inv *inventory) Add(t Type, p pointer) {
 }
 
 // Remove purges Records from the Inventory based on the given Counters.
-// It is called when a Log is compacted from LogDeck, with the Counters
-// kept by the Log being compacted. The oldest Logs in the Deck are always
+// It is called when a Log is compacted from DB, with the Counters
+// kept by the Log being compacted. The oldest Logs in the DB are always
 // compacted first, so we can assume that the Records belonging to that Log
 // are at the very beginning of the Inventory.
 //

--- a/cluster/raft/logdeck/inventory_test.go
+++ b/cluster/raft/logdeck/inventory_test.go
@@ -145,7 +145,7 @@ func TestInventory(t *testing.T) {
 			c.add(rtype)
 		}
 
-		// Now "remove" the Log from the Deck.
+		// Now "remove" the Log from the DB.
 		inv.Remove(c)
 
 		// Make sure that the last five pointers are still there.

--- a/cluster/raft/logdeck/logfile.go
+++ b/cluster/raft/logdeck/logfile.go
@@ -1,0 +1,124 @@
+package logdeck
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"syscall"
+
+	"golang.org/x/exp/mmap"
+)
+
+var logNameRe = regexp.MustCompile(`(\d{20}).log`)
+
+func createLogFile(dir string, id LogID, size int64) (*logFile, error) {
+	filename := filepath.Join(dir, fmt.Sprintf("%020d.log", id))
+
+	w, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+	err = syscall.Fallocate(int(w.Fd()), 0, 0, size)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := mmap.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return &logFile{
+		ID:   id,
+		File: w,
+		Mmap: r,
+		log:  newLog(r, w),
+	}, nil
+}
+
+func openLogFile(filename string) (*logFile, error) {
+	basename := filepath.Base(filename)
+	id, err := strconv.ParseUint(basename[:len(basename)-4], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	w, err := os.OpenFile(filename, os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := mmap.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return &logFile{
+		ID:   LogID(id),
+		File: w,
+		Mmap: r,
+		log:  newLog(r, w),
+	}, nil
+}
+
+// discoverLogFiles searches for files with names matching logNameRe in directory dir,
+// returning a sorted list of filenames.
+func discoverLogFiles(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	logFiles := make([]string, 0)
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+
+		if logNameRe.MatchString(e.Name()) {
+			logFiles = append(logFiles, e.Name())
+		}
+	}
+
+	slices.Sort(logFiles)
+	return logFiles, nil
+}
+
+// logFile represents a Log that is backed by a file.
+// It wraps the basic Log and adds an ID for tracking unique Logs,
+// and the handles of the underlying file.
+type logFile struct {
+	*log
+	ID   LogID
+	File *os.File
+	Mmap *mmap.ReaderAt
+}
+
+func (l *logFile) Sync() error {
+	return syscall.Fdatasync(int(l.File.Fd()))
+}
+
+func (l *logFile) Lock() error {
+	if err := l.Sync(); err != nil {
+		return err
+	}
+
+	if err := os.Truncate(l.File.Name(), l.cursor); err != nil {
+		return err
+	}
+
+	return l.File.Close()
+}
+
+func (l *logFile) Close() error {
+	if err := l.File.Close(); err != nil {
+		if !errors.Is(err, os.ErrClosed) {
+			return err
+		}
+	}
+	return l.Mmap.Close()
+}

--- a/cluster/raft/storage.go
+++ b/cluster/raft/storage.go
@@ -3,7 +3,6 @@ package raft
 import (
 	"bytes"
 	"fmt"
-	"log"
 
 	"github.com/robinkb/cascade-registry/cluster"
 	"github.com/robinkb/cascade-registry/cluster/raft/logdeck"
@@ -24,10 +23,7 @@ func NewDiskStorage(deck logdeck.DB, snap cluster.Snapshotter) (*DiskStorage, er
 		snap: snap,
 	}
 
-	s.deck.ReadAll()
-
 	if s.deck.Count(TypeEntry) > 0 {
-		log.Println("count", s.deck.Count(TypeEntry))
 		value, err := s.deck.First(TypeEntry)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read first entry: %w", err)


### PR DESCRIPTION
All file handlers of a log file should now properly be closed through the lifecycle. Log files are also now locked when they are cut, preventing any more writes. Finally, I got rid of the `DB.ReadAll` method, because it didn't feel ergonomic.

Relates to #74 