### PR TITLE
Add package documentation for package `logdeck`

### DIFF
--- a/cluster/raft/logdeck/doc.go
+++ b/cluster/raft/logdeck/doc.go
@@ -1,5 +1,37 @@
 /*
-LogDeckDB is a queryable WAL, heavily inspired by Bitcask.
-It was initially designed as the backend for an on-disk storage implementation for [go.etcd.io/raft/v3].
+Logdeck is a storage engine that saves values by type and index.
+It was designed as the backend for an on-disk storage implementation for [go.etcd.io/raft/v3].
+You can perhaps think of it as a queryable write-ahead log.
+The design is heavily inspired by Bitcask, but it is not a traditional key/value store.
+
+Applications append values to the DB, which are encoded into records.
+The record contains the value's type, its size, a checksum, and the value itself.
+Internally, the values are written to files called logs, which are managed by the DB.
+There is always one active log, which accepts all new values written to the DB.
+Once a new record would cause the active log to exceed its limit, it is cut.
+The cut log is moved into read-only mode.
+A new active log is then provisioned, and the value is written to the new log.
+A log can be limited either by size, or by record count.
+
+The DB keeps track of all appended values through an internal inventory.
+Every time a value is appended, a pointer to that value is added to the inventory.
+The pointer tracks which log contains the value, its position within the log, and its size.
+The inventory is effectively an in-memory map to each value in the DB.
+This allows the DB to hold a large amount of records with a small memory footprint.
+
+Values can only be appended, and not deleted individually.
+Instead, the DB is compacted once the maximum log count is reached.
+The compaction process deletes the oldest log and its value pointers from the DB.
+Compaction is typically triggered after cutting a new log.
+
+Because the DB decides when to cut and compact, applications can register hooks.
+These hooks are functions that run when the DB cuts and compacts logs.
+Applications can use these hooks to create snapshots, perform internal bookkeeping, etc...
+Some applications may also choose to disable the DB's built-in size limits, and to cut and compact manually.
+
+By combining the in-memory inventory and on-disk logs, values can be retrieved from the DB.
+Values are retrieved by their type and index within the DB at a specific index, or a range of values.
+Applications can query the first (oldest) or last (newest) value of a type.
+Compaction shifts the index of each value, with the oldest remaining value of a type moving to index zero.
 */
 package logdeck

--- a/cluster/raft/logdeck/interface.go
+++ b/cluster/raft/logdeck/interface.go
@@ -43,7 +43,7 @@ type (
 		CompactHook(f CompactHookFunc)
 		// Sync calls syscall.Fdatasync on the active Log, ensuring that buffered
 		// writes to it are flushed to disk. DB only syncs automatically when a Log
-		// is cut and becomes read-noly. Any more syncs are the application's responsibility.
+		// is cut and becomes read-only. Any more syncs are the application's responsibility.
 		Sync() error
 		// Close closes the DB, flushing any pending writes to disk.
 		Close() error


### PR DESCRIPTION
Closes #81 

It's still not as detailed as the Bitcask paper, but this is enough for now. I will add more documentation if the package is ever considered for use outside of Cascade.