### PR TITLE
Seek log's encoder after reading records

### DIFF
--- a/cluster/raft/logdeck/codec.go
+++ b/cluster/raft/logdeck/codec.go
@@ -30,7 +30,7 @@ func (r *record) size() int64 {
 }
 
 // newEncoder returns an Encoder that writes encoded Records to the io.Writer.
-func newEncoder(w io.Writer) *encoder {
+func newEncoder(w io.WriteSeeker) *encoder {
 	return &encoder{
 		dst: w,
 		buf: new(bytes.Buffer),
@@ -40,7 +40,7 @@ func newEncoder(w io.Writer) *encoder {
 // encoder writes encoded Records to the output stream.
 // It is not threadsafe.
 type encoder struct {
-	dst io.Writer
+	dst io.WriteSeeker
 	buf *bytes.Buffer
 }
 
@@ -65,6 +65,11 @@ func (e *encoder) Encode(r *record) (int64, error) {
 
 	n, err := e.dst.Write(e.buf.Bytes())
 	return int64(n), err
+}
+
+// Seek wraps the io.Seek method of the Encoder's backing io.WriteSeeker.
+func (e *encoder) Seek(offset int64, whence int) (int64, error) {
+	return e.dst.Seek(offset, whence)
 }
 
 // newDecoder returns a Decoder that reads decoded Records from the io.ReaderAt.

--- a/cluster/raft/logdeck/codec_test.go
+++ b/cluster/raft/logdeck/codec_test.go
@@ -1,23 +1,22 @@
 package logdeck
 
 import (
-	"bytes"
 	"fmt"
 	"math/rand/v2"
+	"os"
 	"testing"
 
 	. "github.com/robinkb/cascade-registry/testing"
 )
 
 func TestEncodeDecode(t *testing.T) {
+	r, w := testReaderWriter(t)
 	got := new(record)
 	want := randomRecord(128)
 
-	w := new(bytes.Buffer)
 	written, err := newEncoder(w).Encode(want)
 	AssertNoError(t, err)
 
-	r := bytes.NewReader(w.Bytes())
 	read, err := newDecoder(r).RecordAt(got, 0)
 	AssertNoError(t, err).Require()
 
@@ -27,7 +26,8 @@ func TestEncodeDecode(t *testing.T) {
 }
 
 func TestDecodeAllRecords(t *testing.T) {
-	w := new(bytes.Buffer)
+	r, w := testReaderWriter(t)
+
 	enc := newEncoder(w)
 	want := make([]*record, 10)
 
@@ -37,7 +37,6 @@ func TestDecodeAllRecords(t *testing.T) {
 		AssertNoError(t, err).Require()
 	}
 
-	r := bytes.NewReader(w.Bytes())
 	dec := newDecoder(r)
 	got := make([]*record, len(want))
 
@@ -63,14 +62,13 @@ func TestDecodeAllRecords(t *testing.T) {
 }
 
 func TestDecodeValue(t *testing.T) {
+	r, w := testReaderWriter(t)
 	want := randomRecord(rand.Int64N(128) + 128)
+	got := make([]byte, len(want.Value))
 
-	w := new(bytes.Buffer)
 	_, err := newEncoder(w).Encode(want)
 	AssertNoError(t, err)
 
-	got := make([]byte, len(want.Value))
-	r := bytes.NewReader(w.Bytes())
 	_, err = newDecoder(r).ValueAt(got, RecordHeaderLength)
 	AssertNoError(t, err)
 	AssertSlicesEqual(t, got, want.Value)
@@ -106,10 +104,8 @@ func BenchmarkDecode(b *testing.B) {
 	}
 
 	for _, tt := range tc {
-		w := new(bytes.Buffer)
+		r, w := testReaderWriter(b)
 		newEncoder(w).Encode(tt.record) // nolint: errcheck
-
-		r := bytes.NewReader(w.Bytes())
 		dec := newDecoder(r)
 
 		b.Run(fmt.Sprintf("RecordSize: %d, RecordAt", tt.record.size()), func(b *testing.B) {
@@ -133,39 +129,40 @@ func BenchmarkDecode(b *testing.B) {
 
 func TestEncodeDecodeErrorDetection(t *testing.T) {
 	t.Run("truncated record leads to CRC mismatch", func(t *testing.T) {
+		r, w := testReaderWriter(t)
 		got := new(record)
-		w := new(bytes.Buffer)
 
 		_, err := newEncoder(w).Encode(randomRecord(128))
 		AssertNoError(t, err)
 
-		w.Truncate(100)
+		w.(*os.File).Truncate(100)
 
-		r := bytes.NewReader(w.Bytes())
 		_, err = newDecoder(r).RecordAt(got, 0)
 		AssertErrorIs(t, err, ErrShortRead)
 	})
 
 	t.Run("corrupt record leads to CRC mismatch", func(t *testing.T) {
+		r, w := testReaderWriter(t)
+		want := randomRecord(128)
 		got := new(record)
-		w := new(bytes.Buffer)
 
-		_, err := newEncoder(w).Encode(randomRecord(128))
+		_, err := newEncoder(w).Encode(want)
 		AssertNoError(t, err).Require()
 
-		b := w.Bytes()
-		b[len(b)-10] = byte(255)
-		w.Reset()
-		w.Write(b)
+		// Corrupt the record by writing to the middle of it.
+		_, err = w.(*os.File).WriteAt(
+			[]byte{byte(255)},
+			int64(len(want.Value)-10),
+		)
+		AssertNoError(t, err).Require()
 
-		r := bytes.NewReader(w.Bytes())
 		_, err = newDecoder(r).RecordAt(got, 0)
 		AssertErrorIs(t, err, ErrChecksumMismatch)
 	})
 }
 
 func TestEncodeDecodeDoesNotAllocate(t *testing.T) {
-	r, w := tempLog(t)
+	r, w := testReaderWriter(t)
 	encoder := newEncoder(w)
 	decoder := newDecoder(r)
 

--- a/cluster/raft/logdeck/codec_test.go
+++ b/cluster/raft/logdeck/codec_test.go
@@ -135,7 +135,8 @@ func TestEncodeDecodeErrorDetection(t *testing.T) {
 		_, err := newEncoder(w).Encode(randomRecord(128))
 		AssertNoError(t, err)
 
-		w.(*os.File).Truncate(100)
+		err = w.(*os.File).Truncate(100)
+		AssertNoError(t, err).Require()
 
 		_, err = newDecoder(r).RecordAt(got, 0)
 		AssertErrorIs(t, err, ErrShortRead)

--- a/cluster/raft/logdeck/db_test.go
+++ b/cluster/raft/logdeck/db_test.go
@@ -249,33 +249,86 @@ func TestDBCompact(t *testing.T) {
 }
 
 func TestDBOpenExisting(t *testing.T) {
-	dir := t.TempDir()
-	db := testDB(t, dir, &Options{
-		MaxLogCount: 8,
+	// Fails atm because internal cursor of a Log's encoder
+	// does not get set when opening a file that already has content.
+	// Could solve by reworking Encoder to have EncodeAt method instead,
+	// but that's kinda awkward.
+	// Should probably seek the file instead.
+	// This test is probably useful to keep. Maybe. Let's reproduce on Log.
+	t.Run("re-open db and write data", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Cleanup(func() {
+			os.RemoveAll(dir) // nolint: errcheck
+		})
+
+		db := testDB(t, dir, nil)
+
+		// Generate some random values to write.
+		// Half will be written now, and half after recovery.
+		wantType := randomType()
+		wantValues := RandomBytesN(8, 1<<10, 10<<10)
+
+		// Write the first half.
+		for i := 0; i < len(wantValues)/2; i++ {
+			err := db.Append(wantType, wantValues[i])
+			AssertNoError(t, err).Require()
+		}
+
+		err := db.Close()
+		AssertNoError(t, err).Require()
+
+		// Re-open DB and rebuild state from directory.
+		db = testDB(t, dir, nil)
+
+		// Write the remaining values
+		for i := len(wantValues) / 2; i < len(wantValues); i++ {
+			err := db.Append(wantType, wantValues[i])
+			AssertNoError(t, err).Require()
+		}
+
+		// Make sure that all are available.
+		for i, wantValue := range wantValues {
+			got, err := db.Get(wantType, i)
+			AssertNoError(t, err)
+			AssertSlicesEqual(t, got, wantValue)
+		}
 	})
 
-	// Generate a bunch of random values, appending each to the DB.
-	// We call Cut after every Append, because we want to create
-	// a lot of Log files. We also need to trigger at least a few
-	// compactions, so we should append more values than MaxLogCount.
-	wantType := randomType()
-	wantValues := RandomBytesN(16, 1<<10, 10<<10)
-	for _, value := range wantValues {
-		err := db.Append(wantType, value)
+	t.Run("recover after cuts and compactions", func(t *testing.T) {
+		dir := t.TempDir()
+		db := testDB(t, dir, &Options{
+			MaxLogCount: 8,
+		})
+
+		// Generate a bunch of random values, appending each to the DB.
+		// We call Cut after every Append, because we want to create
+		// a lot of Log files. We also need to trigger at least a few
+		// compactions, so we should append more values than MaxLogCount.
+		wantType := randomType()
+		wantValues := RandomBytesN(16, 1<<10, 10<<10)
+		for _, value := range wantValues {
+			err := db.Append(wantType, value)
+			AssertNoError(t, err).Require()
+			err = db.Cut()
+			AssertNoError(t, err).Require()
+		}
+
+		// The amount of values left in DB after compaction.
+		remainingValueCount := db.Count(wantType)
+
+		err := db.Close()
 		AssertNoError(t, err).Require()
-		err = db.Cut()
-		AssertNoError(t, err).Require()
-	}
 
-	err := db.Close()
-	AssertNoError(t, err).Require()
+		// Open a new DB in the same directory.
+		db = testDB(t, dir, nil)
 
-	// Open a new DB in the same directory.
-	db = testDB(t, dir, nil)
-
-	got, err := db.Last(wantType)
-	AssertNoError(t, err).Require()
-	AssertSlicesEqual(t, got, wantValues[len(wantValues)-1])
+		// Check all remaining values
+		for i := range remainingValueCount {
+			got, err := db.Get(wantType, i)
+			AssertNoError(t, err)
+			AssertSlicesEqual(t, got, wantValues[remainingValueCount+i])
+		}
+	})
 }
 
 func testDB(t *testing.T, dir string, opts *Options) DB {

--- a/cluster/raft/logdeck/log.go
+++ b/cluster/raft/logdeck/log.go
@@ -7,7 +7,7 @@ import (
 	"iter"
 )
 
-func newLog(r io.ReaderAt, w io.Writer) *log {
+func newLog(r io.ReaderAt, w io.WriteSeeker) *log {
 	return &log{
 		enc:      newEncoder(w),
 		dec:      newDecoder(r),
@@ -45,6 +45,16 @@ func (l *log) ValueAt(p []byte, offset int64) error {
 
 func (l *log) All() iter.Seq[*record] {
 	return func(yield func(*record) bool) {
+		defer func() {
+			// Move the encoder's internal cursor to the end of the log
+			// after reading all records within it. Ensures that new appends
+			// are appended at the end of the log, and existing records
+			// are not overwritten.
+			if _, err := l.enc.Seek(l.cursor, io.SeekStart); err != nil {
+				panic("failed to seek encoder")
+			}
+		}()
+
 		r := new(record)
 		for {
 			n, err := l.dec.RecordAt(r, l.cursor)

--- a/cluster/raft/logdeck/log_test.go
+++ b/cluster/raft/logdeck/log_test.go
@@ -11,9 +11,9 @@ import (
 	"golang.org/x/exp/mmap"
 )
 
-func tempLog(t *testing.T) (io.ReaderAt, io.Writer) {
+func testReaderWriter(t testing.TB) (io.ReaderAt, io.WriteSeeker) {
 	filename := filepath.Join(t.TempDir(), "log.bin")
-	w, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	w, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
 	AssertNoError(t, err).Require()
 
 	r, err := os.OpenFile(filename, os.O_RDONLY, 0644)
@@ -35,7 +35,7 @@ func tempLog(t *testing.T) (io.ReaderAt, io.Writer) {
 
 func TestLogReadAll(t *testing.T) {
 	want := randomRecordsN(10, 16, 32)
-	r, w := tempLog(t)
+	r, w := testReaderWriter(t)
 
 	l := newLog(r, w)
 

--- a/cluster/raft/node.go
+++ b/cluster/raft/node.go
@@ -36,7 +36,10 @@ type (
 // Also, I should probably decompose this more and allow passing dependencies
 // like a Mesh and DiskStorage directly.
 func NewNode(id uint64, addr netip.AddrPort, peers []Peer, workDir string, snap cluster.SnapshotRestorer) Node {
-	db, err := logdeck.Open(workDir, nil)
+	db, err := logdeck.Open(workDir, &logdeck.Options{
+		MaxLogSize:  64 << 20,
+		MaxLogCount: 3,
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/cluster/raft/storage.go
+++ b/cluster/raft/storage.go
@@ -213,7 +213,7 @@ func (s *DiskStorage) Term(i uint64) (uint64, error) {
 	var entry raftpb.Entry
 	err = entry.Unmarshal(value)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to unmarshal entry [i: %d] [fi: %d] [li: %d]: %w ", i, fi, li, err)
 	}
 
 	return entry.Term, nil

--- a/cmd/dump/main.go
+++ b/cmd/dump/main.go
@@ -29,6 +29,8 @@ func main() {
 		}
 	}()
 
+	cursor := 0
+
 	for t, val := range logdeck.DumpLog(f) {
 		switch t {
 		case raft.TypeEntry:
@@ -37,7 +39,7 @@ func main() {
 			if err != nil {
 				log.Fatalln(err)
 			}
-			fmt.Printf("%-7d [entry   ] index %d, term %d, type %s\n", len(val), entry.Index, entry.Term, entry.Type.String())
+			fmt.Printf("%8d:%-7d [entry   ] index %d, term %d, type %s\n", cursor, len(val), entry.Index, entry.Term, entry.Type.String())
 
 		case raft.TypeHardState:
 			var hs raftpb.HardState
@@ -45,7 +47,7 @@ func main() {
 			if err != nil {
 				log.Fatalln(err)
 			}
-			fmt.Printf("%-7d [state   ] commit %d, term %d, vote %d\n", len(val), hs.Commit, hs.Term, hs.Vote)
+			fmt.Printf("%8d:%-7d [state   ] commit %d, term %d, vote %d\n", cursor, len(val), hs.Commit, hs.Term, hs.Vote)
 
 		case raft.TypeSnapshot:
 			var snap raftpb.Snapshot
@@ -53,7 +55,9 @@ func main() {
 			if err != nil {
 				log.Fatalln(err)
 			}
-			fmt.Printf("%-7d [snapshot] index %d, term %d, confState %s\n", len(val), snap.Metadata.Index, snap.Metadata.Term, snap.Metadata.ConfState.String())
+			fmt.Printf("%8d:%-7d [snapshot] index %d, term %d, confState %s\n", cursor, len(val), snap.Metadata.Index, snap.Metadata.Term, snap.Metadata.ConfState.String())
 		}
+
+		cursor += logdeck.RecordHeaderLength + len(val)
 	}
 }

--- a/testing/assert.go
+++ b/testing/assert.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Result struct {
-	T       *testing.T
+	T       testing.TB
 	Success bool
 }
 
@@ -27,7 +27,7 @@ func (r *Result) Require() {
 	}
 }
 
-func AssertErrorIs(t *testing.T, got, want error) *Result {
+func AssertErrorIs(t testing.TB, got, want error) *Result {
 	t.Helper()
 
 	if !errors.Is(got, want) {
@@ -37,7 +37,7 @@ func AssertErrorIs(t *testing.T, got, want error) *Result {
 	return &Result{t, true}
 }
 
-func AssertPanics(t *testing.T, want error) {
+func AssertPanics(t testing.TB, want error) {
 	got := recover()
 	if got == nil {
 		t.Error("expected a panic")
@@ -46,7 +46,7 @@ func AssertPanics(t *testing.T, want error) {
 	AssertErrorIs(t, got.(error), want)
 }
 
-func AssertNoError(t *testing.T, got error) *Result {
+func AssertNoError(t testing.TB, got error) *Result {
 	t.Helper()
 
 	if got != nil {
@@ -56,7 +56,7 @@ func AssertNoError(t *testing.T, got error) *Result {
 	return &Result{t, true}
 }
 
-func AssertResponseCode(t *testing.T, got *http.Response, want int) *Result {
+func AssertResponseCode(t testing.TB, got *http.Response, want int) *Result {
 	t.Helper()
 
 	if got.StatusCode != want {
@@ -69,7 +69,7 @@ func AssertResponseCode(t *testing.T, got *http.Response, want int) *Result {
 	return &Result{t, true}
 }
 
-func AssertResponseHeader(t *testing.T, got *http.Response, header string, want ...string) *Result {
+func AssertResponseHeader(t testing.TB, got *http.Response, header string, want ...string) *Result {
 	t.Helper()
 
 	// Normalize header name, because they are supposed to be case-insensitive.
@@ -89,7 +89,7 @@ func AssertResponseHeader(t *testing.T, got *http.Response, header string, want 
 	return &Result{t, true}
 }
 
-func AssertResponseHeaderSet(t *testing.T, got *http.Response, header string) *Result {
+func AssertResponseHeaderSet(t testing.TB, got *http.Response, header string) *Result {
 	t.Helper()
 
 	header = textproto.CanonicalMIMEHeaderKey(header)
@@ -102,7 +102,7 @@ func AssertResponseHeaderSet(t *testing.T, got *http.Response, header string) *R
 	return &Result{t, true}
 }
 
-func AssertResponseHeaderUnset(t *testing.T, got *http.Response, header string) *Result {
+func AssertResponseHeaderUnset(t testing.TB, got *http.Response, header string) *Result {
 	t.Helper()
 
 	header = textproto.CanonicalMIMEHeaderKey(header)
@@ -115,7 +115,7 @@ func AssertResponseHeaderUnset(t *testing.T, got *http.Response, header string) 
 	return &Result{t, true}
 }
 
-func AssertResponseBodyEquals(t *testing.T, got *http.Response, want []byte) *Result {
+func AssertResponseBodyEquals(t testing.TB, got *http.Response, want []byte) *Result {
 	t.Helper()
 
 	data, err := io.ReadAll(got.Body)
@@ -131,7 +131,7 @@ func AssertResponseBodyEquals(t *testing.T, got *http.Response, want []byte) *Re
 	return &Result{t, true}
 }
 
-func AssertResponseBodyUnmarshals[T any](t *testing.T, got *http.Response, obj T) *Result {
+func AssertResponseBodyUnmarshals[T any](t testing.TB, got *http.Response, obj T) *Result {
 	t.Helper()
 
 	data, err := io.ReadAll(got.Body)
@@ -148,7 +148,7 @@ func AssertResponseBodyUnmarshals[T any](t *testing.T, got *http.Response, obj T
 	return &Result{t, true}
 }
 
-func AssertIndex(t *testing.T, got, want *v1.Index) *Result {
+func AssertIndex(t testing.TB, got, want *v1.Index) *Result {
 	t.Helper()
 
 	if len(got.Manifests) != len(want.Manifests) {
@@ -171,7 +171,7 @@ func AssertIndex(t *testing.T, got, want *v1.Index) *Result {
 	return &Result{t, true}
 }
 
-func AssertEqual[T comparable](t *testing.T, got, want T) *Result {
+func AssertEqual[T comparable](t testing.TB, got, want T) *Result {
 	t.Helper()
 
 	if got != want {
@@ -182,7 +182,7 @@ func AssertEqual[T comparable](t *testing.T, got, want T) *Result {
 	return &Result{t, true}
 }
 
-func AssertSlicesEqual[S ~[]E, E comparable](t *testing.T, got S, want S) *Result {
+func AssertSlicesEqual[S ~[]E, E comparable](t testing.TB, got S, want S) *Result {
 	t.Helper()
 
 	if len(got) != len(want) {
@@ -191,13 +191,16 @@ func AssertSlicesEqual[S ~[]E, E comparable](t *testing.T, got S, want S) *Resul
 	}
 
 	if !slices.Equal(got, want) {
-		t.Errorf("slices are not equal;\ngot\n%v\nwant\n%v", got, want)
+		t.Errorf("slices are not equal")
+		if len(want) <= 32 && len(got) <= 32 {
+			t.Errorf("got\n%v\nwant\n%v", got, want)
+		}
 		return &Result{t, false}
 	}
 	return &Result{t, true}
 }
 
-func AssertMapsEqual[M1, M2 ~map[K]V, K, V comparable](t *testing.T, got M1, want M2) *Result {
+func AssertMapsEqual[M1, M2 ~map[K]V, K, V comparable](t testing.TB, got M1, want M2) *Result {
 	t.Helper()
 
 	if !maps.Equal(got, want) {
@@ -208,7 +211,7 @@ func AssertMapsEqual[M1, M2 ~map[K]V, K, V comparable](t *testing.T, got M1, wan
 	return &Result{t, true}
 }
 
-func AssertDeepEqual(t *testing.T, got, want any) *Result {
+func AssertDeepEqual(t testing.TB, got, want any) *Result {
 	t.Helper()
 
 	if !reflect.DeepEqual(got, want) {


### PR DESCRIPTION
Fixes corruption of `logdeck.DB` from re-opening a DB and appending values to it.