### PR TITLE
Remove unneeded t.Cleanup usage

### DIFF
--- a/cluster/raft/logdeck/db_test.go
+++ b/cluster/raft/logdeck/db_test.go
@@ -3,7 +3,6 @@ package logdeck
 import (
 	"errors"
 	"math/rand/v2"
-	"os"
 	"testing"
 
 	. "github.com/robinkb/cascade-registry/testing"
@@ -251,10 +250,6 @@ func TestDBCompact(t *testing.T) {
 func TestDBOpenExisting(t *testing.T) {
 	t.Run("re-open db and write data", func(t *testing.T) {
 		dir := t.TempDir()
-		t.Cleanup(func() {
-			os.RemoveAll(dir) // nolint: errcheck
-		})
-
 		db := testDB(t, dir, nil)
 
 		// Generate some random values to write.
@@ -326,10 +321,6 @@ func TestDBOpenExisting(t *testing.T) {
 }
 
 func testDB(t *testing.T, dir string, opts *Options) DB {
-	t.Cleanup(func() {
-		os.RemoveAll(dir) // nolint: errcheck
-	})
-
 	deck, err := Open(dir, opts)
 	AssertNoError(t, err).Require()
 

--- a/cluster/raft/node_test.go
+++ b/cluster/raft/node_test.go
@@ -317,5 +317,5 @@ func TestMetadataReplication(t *testing.T) {
 }
 
 func wait() {
-	time.Sleep(2500 * time.Microsecond)
+	time.Sleep(3000 * time.Microsecond)
 }

--- a/cluster/raft/storage_test.go
+++ b/cluster/raft/storage_test.go
@@ -3,7 +3,6 @@ package raft
 import (
 	"math"
 	"math/rand/v2"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -381,10 +380,6 @@ func (i index) terms(terms ...uint64) []raftpb.Entry {
 
 func testDB(t *testing.T, opts *logdeck.Options) logdeck.DB {
 	dir := t.TempDir()
-	t.Cleanup(func() {
-		os.RemoveAll(dir) // nolint: errcheck
-	})
-
 	db, err := logdeck.Open(dir, opts)
 	AssertNoError(t, err).Require()
 

--- a/repository/service_test.go
+++ b/repository/service_test.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"os"
 	"testing"
 
 	"github.com/robinkb/cascade-registry/store"
@@ -71,10 +70,6 @@ func TestWithBoltDBStore(t *testing.T) {
 			metadata := boltdb.NewMetadataStore(tmp)
 			blobs := inmemory.NewBlobStore()
 
-			t.Cleanup(func() {
-				os.RemoveAll(tmp) // nolint: errcheck
-			})
-
 			return metadata, blobs
 		},
 	})
@@ -86,10 +81,6 @@ func TestWithFilesystemStore(t *testing.T) {
 			tmp := t.TempDir()
 			metadata := inmemory.NewMetadataStore()
 			blobs := fs.NewBlobStore(tmp)
-
-			t.Cleanup(func() {
-				os.RemoveAll(tmp) // nolint: errcheck
-			})
 
 			return metadata, blobs
 		},

--- a/store/boltdb/metadata_test.go
+++ b/store/boltdb/metadata_test.go
@@ -1,7 +1,6 @@
 package boltdb
 
 import (
-	"os"
 	"testing"
 
 	"github.com/robinkb/cascade-registry/store"
@@ -13,10 +12,6 @@ func TestMetadataSuite(t *testing.T) {
 	suite.Run(t, &storesuite.MetadataSuite{
 		Constructor: func() store.Metadata {
 			tmp := t.TempDir()
-			t.Cleanup(func() {
-				os.RemoveAll(tmp) // nolint: errcheck
-			})
-
 			return NewMetadataStore(tmp)
 		},
 	})


### PR DESCRIPTION
`t.TempDir()` result is removed automatically. No idea why I started doing this.