### PR TITLE
Fix concurrent repository creation

### DIFF
--- a/registry/repository/blobs_test.go
+++ b/registry/repository/blobs_test.go
@@ -25,7 +25,7 @@ func TestStatBlob(t *testing.T) {
 			GetBlob(id).
 			Return(nil)
 
-		r := NewRepositoryService(blobs, repo)
+		r := New(blobs, repo)
 		got, err := r.StatBlob(id.String())
 		AssertNoError(t, err)
 		AssertDeepEqual(t, got, info)

--- a/registry/repository/manifest_test.go
+++ b/registry/repository/manifest_test.go
@@ -43,7 +43,7 @@ func TestPutManifest(t *testing.T) {
 			PutManifest(id, wantMetadata, wantReferences).
 			Return(nil)
 
-		svc := NewRepositoryService(blobs, repo)
+		svc := New(blobs, repo)
 		subj, err := svc.PutManifest(id.String(), data)
 		AssertEqual(t, subj, "")
 		AssertNoError(t, err)
@@ -63,7 +63,7 @@ func TestPutManifest(t *testing.T) {
 			PutManifest(referrer.Digest, referrer.Metadata(), referrer.References()).
 			Return(nil)
 
-		svc := NewRepositoryService(blobs, repo)
+		svc := New(blobs, repo)
 		id, err := svc.PutManifest(referrer.Digest.String(), referrer.Bytes)
 		AssertNoError(t, err)
 		AssertEqual(t, id, subject.Digest)
@@ -94,7 +94,7 @@ func TestPutManifest(t *testing.T) {
 			PutManifest(id, wantMedata, wantReferences).
 			Return(nil)
 
-		svc := NewRepositoryService(blobs, repo)
+		svc := New(blobs, repo)
 		subj, err := svc.PutManifest(id.String(), data)
 		AssertNoError(t, err)
 		AssertEqual(t, subj, "")
@@ -120,7 +120,7 @@ func TestDeleteManifest(t *testing.T) {
 				Return(nil)
 		}
 
-		svc := NewRepositoryService(blobs, repo)
+		svc := New(blobs, repo)
 		err := svc.DeleteManifest(manifest.Digest.String())
 		AssertNoError(t, err)
 	})

--- a/registry/repository/service.go
+++ b/registry/repository/service.go
@@ -32,7 +32,7 @@ type (
 	}
 )
 
-func NewRepositoryService(blobs store.Blobs, repo store.Repository) Service {
+func New(blobs store.Blobs, repo store.Repository) Service {
 	return &repositoryService{
 		blobs: blobs,
 		repo:  repo,

--- a/registry/repository/tags_test.go
+++ b/registry/repository/tags_test.go
@@ -25,7 +25,7 @@ func TestDeleteTags(t *testing.T) {
 				Return(nil)
 		}
 
-		svc := NewRepositoryService(blobs, repo)
+		svc := New(blobs, repo)
 		err := svc.DeleteTag(tag)
 		AssertNoError(t, err)
 	})

--- a/registry/service.go
+++ b/registry/service.go
@@ -34,7 +34,7 @@ func (r *registryService) CreateRepository(name string) (repository.Service, err
 			return nil, err
 		}
 	}
-	return repository.NewRepositoryService(r.blobs, repo), nil
+	return repository.New(r.blobs, repo), nil
 }
 
 func (r *registryService) GetRepository(name string) (repository.Service, error) {
@@ -43,12 +43,9 @@ func (r *registryService) GetRepository(name string) (repository.Service, error)
 		if !errors.Is(err, store.ErrRepositoryNotFound) {
 			return nil, err
 		}
-		repo, err = r.meta.CreateRepository(name)
-		if err != nil {
-			return nil, err
-		}
+		return r.CreateRepository(name)
 	}
-	return repository.NewRepositoryService(r.blobs, repo), nil
+	return repository.New(r.blobs, repo), nil
 }
 
 func (r *registryService) DeleteRepository(name string) error {

--- a/registry/service_test.go
+++ b/registry/service_test.go
@@ -69,20 +69,18 @@ func TestRepository(t *testing.T) {
 				AssertErrorIs(t, err, repository.ErrNameUnknown)
 			})
 
-			t.Run("Attempting to create the same repository concurrently doesn't fail", func(t *testing.T) {
+			t.Run("Attempting to get the same repository concurrently doesn't fail", func(t *testing.T) {
 				// This can occur when repositories are created ad-hoc during an image push,
 				// where multiple layers are pushed concurrently.
 				name := RandomName()
-				routines := 3
+				routines := 10
 
 				var wg sync.WaitGroup
-				wg.Add(routines)
 				for range routines {
-					go func() {
-						_, err := service.CreateRepository(name)
+					wg.Go(func() {
+						_, err := service.GetRepository(name)
 						AssertNoError(t, err)
-						wg.Done()
-					}()
+					})
 				}
 				wg.Wait()
 			})

--- a/registry/store/driver/boltdb/metadata_types.go
+++ b/registry/store/driver/boltdb/metadata_types.go
@@ -3,6 +3,7 @@ package boltdb
 import (
 	"bytes"
 	"encoding/gob"
+	"fmt"
 	"iter"
 
 	"github.com/gofrs/uuid/v5"
@@ -27,7 +28,7 @@ func (o sharedBlobs) addBlob(id digest.Digest) sharedBlob {
 }
 
 func (o sharedBlobs) removeBlob(id digest.Digest) {
-	_ = o.b.DeleteBucket([]byte(id))
+	must(o.b.DeleteBucket([]byte(id)))
 }
 
 // sharedBlob represents a single blob in the blob store.
@@ -37,11 +38,11 @@ type sharedBlob struct {
 }
 
 func (o sharedBlob) addOwner(name string) {
-	_ = o.b.Put([]byte(name), nil)
+	must(o.b.Put([]byte(name), nil))
 }
 
 func (o sharedBlob) removeOwner(name string) {
-	_ = o.b.Delete([]byte(name))
+	must(o.b.Delete([]byte(name)))
 }
 
 func (o sharedBlob) hasOwners() bool {
@@ -85,7 +86,7 @@ func (o repoBlobs) addBlob(id digest.Digest) repoBlob {
 }
 
 func (o repoBlobs) removeBlob(id digest.Digest) {
-	_ = o.b.DeleteBucket([]byte(id))
+	must(o.b.DeleteBucket([]byte(id)))
 }
 
 type repoBlob struct {
@@ -95,11 +96,11 @@ type repoBlob struct {
 func (o repoBlob) found() bool { return o.b != nil }
 
 func (o repoBlob) addOwner(id digest.Digest) {
-	_ = o.b.Put([]byte(id), nil)
+	must(o.b.Put([]byte(id), nil))
 }
 
 func (o repoBlob) removeOwner(id digest.Digest) {
-	_ = o.b.Delete([]byte(id))
+	must(o.b.Delete([]byte(id)))
 }
 
 func (o repoBlob) hasOwners() bool {
@@ -117,26 +118,26 @@ func (o manifests) manifest(id digest.Digest) manifest {
 func (o manifests) addManifest(id digest.Digest, meta store.Manifest, refs store.References) manifest {
 	b, _ := o.b.CreateBucket([]byte(id))
 	for _, bucket := range manifestBuckets {
-		_, _ = b.CreateBucket(bucket)
+		must(b.CreateBucket(bucket))
 	}
 
 	buf := new(bytes.Buffer)
 	if err := gob.NewEncoder(buf).Encode(&meta); err != nil {
 		panic(err)
 	}
-	_ = b.Put(_METADATA, buf.Bytes())
+	must(b.Put(_METADATA, buf.Bytes()))
 
 	buf = new(bytes.Buffer)
 	if err := gob.NewEncoder(buf).Encode(&refs); err != nil {
 		panic(err)
 	}
-	_ = b.Put(_REFERENCES, buf.Bytes())
+	must(b.Put(_REFERENCES, buf.Bytes()))
 
 	return manifest{b}
 }
 
 func (o manifests) removeManifest(id digest.Digest) {
-	_ = o.b.DeleteBucket([]byte(id))
+	must(o.b.DeleteBucket([]byte(id)))
 }
 
 type manifest struct {
@@ -165,37 +166,37 @@ func (o manifest) references() (refs store.References) {
 
 func (o manifest) referrers() iter.Seq[digest.Digest] {
 	return func(yield func(digest.Digest) bool) {
-		_ = o.b.Bucket(_REFERRERS).ForEach(func(id, _ []byte) error {
+		must(o.b.Bucket(_REFERRERS).ForEach(func(id, _ []byte) error {
 			if !yield(digest.Digest(id)) {
 				return nil
 			}
 			return nil
-		})
+		}))
 	}
 }
 
 func (o manifest) addReferrer(id digest.Digest) {
-	_ = o.b.Bucket(_REFERRERS).Put([]byte(id), nil)
+	must(o.b.Bucket(_REFERRERS).Put([]byte(id), nil))
 }
 
 func (o manifest) removeReferrer(id digest.Digest) {
-	_ = o.b.Bucket(_REFERRERS).Delete([]byte(id))
+	must(o.b.Bucket(_REFERRERS).Delete([]byte(id)))
 }
 
 func (o manifest) addManifestOwner(id digest.Digest) {
-	_ = o.b.Bucket(_MANIFESTS).Put([]byte(id), nil)
+	must(o.b.Bucket(_MANIFESTS).Put([]byte(id), nil))
 }
 
 func (o manifest) removeManifestOwner(id digest.Digest) {
-	_ = o.b.Bucket(_MANIFESTS).Delete([]byte(id))
+	must(o.b.Bucket(_MANIFESTS).Delete([]byte(id)))
 }
 
 func (o manifest) addTagOwner(tag string) {
-	_ = o.b.Bucket(_TAGS).Put([]byte(tag), nil)
+	must(o.b.Bucket(_TAGS).Put([]byte(tag), nil))
 }
 
 func (o manifest) removeTagOwner(tag string) {
-	_ = o.b.Bucket(_TAGS).Delete([]byte(tag))
+	must(o.b.Bucket(_TAGS).Delete([]byte(tag)))
 }
 
 func (o manifest) hasOwners() bool {
@@ -212,11 +213,11 @@ func (o tags) tag(t string) digest.Digest {
 }
 
 func (o tags) addTag(t string, id digest.Digest) {
-	_ = o.b.Put([]byte(t), []byte(id))
+	must(o.b.Put([]byte(t), []byte(id)))
 }
 
 func (o tags) removeTag(t string) {
-	_ = o.b.Delete([]byte(t))
+	must(o.b.Delete([]byte(t)))
 }
 
 type uploads struct {
@@ -241,9 +242,25 @@ func (o uploads) putUpload(upload *store.UploadSession) {
 	if err := gob.NewEncoder(buf).Encode(upload); err != nil {
 		panic(err)
 	}
-	_ = o.b.Put(upload.ID.Bytes(), buf.Bytes())
+	must(o.b.Put(upload.ID.Bytes(), buf.Bytes()))
 }
 
 func (o uploads) removeUpload(id uuid.UUID) {
-	_ = o.b.Delete(id.Bytes())
+	must(o.b.Delete(id.Bytes()))
+}
+
+// must panics if any parameters are a non-nil error.
+// It is used when an error would indicate a programmer mistake.
+func must(parameters ...any) {
+	for _, p := range parameters {
+		if err, ok := p.(error); ok {
+			if err != nil {
+				msg := fmt.Sprintf(
+					"unexpected error in the boltdb metadata store driver;"+
+						"this should never happen and should be reported as a bug: %s", err,
+				)
+				panic(msg)
+			}
+		}
+	}
 }


### PR DESCRIPTION
This can occur during image pushes to a new repository, because they are created on-demand.

Also renamed a function to be shorter, and added error checking in the boltdb driver. Curious to see if it ever does panic.