### PR TITLE
Fix metadata bug triggered by manifest with duplicate layers

### DIFF
--- a/registry/store/driver/boltdb/metadata.go
+++ b/registry/store/driver/boltdb/metadata.go
@@ -388,7 +388,12 @@ func (r *repositoryStore) deleteManifest(tx *bolt.Tx, id digest.Digest) ([]diges
 	}
 
 	for _, layerDigest := range refs.Layers {
-		blobs.blob(layerDigest).removeOwner(id)
+		blob := blobs.blob(layerDigest)
+		if !blob.found() {
+			continue
+		}
+		blob.removeOwner(id)
+
 		if err := r.deleteBlob(tx, layerDigest); err != nil {
 			if errors.Is(err, store.ErrBlobInUse) {
 				continue

--- a/registry/store/driver/boltdb/metadata.go
+++ b/registry/store/driver/boltdb/metadata.go
@@ -404,7 +404,12 @@ func (r *repositoryStore) deleteManifest(tx *bolt.Tx, id digest.Digest) ([]diges
 	}
 
 	for _, manifestDigest := range refs.Manifests {
-		manifests.manifest(manifestDigest).removeManifestOwner(id)
+		manifest := manifests.manifest(manifestDigest)
+		if !manifest.found() {
+			continue
+		}
+		manifest.removeManifestOwner(id)
+
 		digests, err := r.deleteManifest(tx, manifestDigest)
 		if err != nil {
 			if errors.Is(err, store.ErrManifestInUse) {

--- a/registry/store/driver/inmemory/metadata.go
+++ b/registry/store/driver/inmemory/metadata.go
@@ -280,7 +280,8 @@ func (r *repositoryStore) DeleteManifest(id digest.Digest) ([]digest.Digest, err
 	for _, layerDigest := range manifest.Refs.Layers {
 		delete(r.repo.Blobs[layerDigest], id)
 		if err := r.DeleteBlob(layerDigest); err != nil {
-			if errors.Is(err, store.ErrBlobInUse) {
+			if errors.Is(err, store.ErrBlobInUse) ||
+				errors.Is(err, store.ErrBlobNotFound) {
 				continue
 			}
 			return deleted, err

--- a/registry/store/driver/inmemory/metadata.go
+++ b/registry/store/driver/inmemory/metadata.go
@@ -293,7 +293,8 @@ func (r *repositoryStore) DeleteManifest(id digest.Digest) ([]digest.Digest, err
 		delete(r.repo.Manifests[manifestDigest].Manifests, id)
 		digests, err := r.DeleteManifest(manifestDigest)
 		if err != nil {
-			if errors.Is(err, store.ErrManifestInUse) {
+			if errors.Is(err, store.ErrManifestInUse) ||
+				errors.Is(err, store.ErrManifestNotFound) {
 				continue
 			}
 			return deleted, err

--- a/registry/store/suite/metadata.go
+++ b/registry/store/suite/metadata.go
@@ -704,6 +704,26 @@ func (s *MetadataSuite) TestManifests() {
 		AssertSlicesEqual(t, deleted, digests)
 	})
 
+	// I do not see this happening in reality, but let's be safe and design defensively.
+	s.T().Run("does not error when deleting index with 'duplicate' manifests", func(t *testing.T) {
+		repo := s.RepositoryConstructor(t)
+		indexDigest, manifestDigest := RandomDigest(), RandomDigest()
+		wantDeleted := []digest.Digest{indexDigest, manifestDigest}
+		slices.Sort(wantDeleted)
+
+		err := repo.PutManifest(manifestDigest, store.Manifest{}, store.References{})
+		AssertNoError(t, err)
+		err = repo.PutManifest(indexDigest, store.Manifest{}, store.References{
+			Manifests: []digest.Digest{manifestDigest, manifestDigest},
+		})
+		AssertNoError(t, err)
+
+		deleted, err := repo.DeleteManifest(indexDigest)
+		AssertNoError(t, err)
+		slices.Sort(deleted)
+		AssertSlicesEqual(t, deleted, wantDeleted)
+	})
+
 	s.T().Run("deleting manifest referenced in index returns ErrManifestInUse", func(t *testing.T) {
 		repo := s.RepositoryConstructor(t)
 		indexDigest, imageDigest := RandomDigest(), RandomDigest()

--- a/registry/store/suite/metadata.go
+++ b/registry/store/suite/metadata.go
@@ -597,6 +597,25 @@ func (s *MetadataSuite) TestManifests() {
 		AssertErrorIs(t, err, store.ErrBlobNotFound)
 	})
 
+	s.T().Run("does not error when deleting manifest with 'duplicate' layers", func(t *testing.T) {
+		repo := s.RepositoryConstructor(t)
+		manifestDigest, layerDigest := RandomDigest(), RandomDigest()
+		wantDeleted := []digest.Digest{manifestDigest, layerDigest}
+		slices.Sort(wantDeleted)
+
+		err := repo.PutBlob(layerDigest)
+		AssertNoError(t, err)
+		err = repo.PutManifest(manifestDigest, store.Manifest{}, store.References{
+			Layers: []digest.Digest{layerDigest, layerDigest},
+		})
+		AssertNoError(t, err)
+
+		deleted, err := repo.DeleteManifest(manifestDigest)
+		AssertNoError(t, err)
+		slices.Sort(deleted)
+		AssertSlicesEqual(t, deleted, wantDeleted)
+	})
+
 	s.T().Run("deleting referenced layer blob returns ErrBlobInUse", func(t *testing.T) {
 		repo := s.RepositoryConstructor(t)
 		manifestDigest, layerDigest := RandomDigest(), RandomDigest()


### PR DESCRIPTION
Encountered a manifest in the while that had the same layer digest referenced more than once. This caused an error (panic) in the BoltDB driver. Added a test to reproduce the bug, and the bug was also present in the in-memory implementation.

There is a similar case that could theoretically happen with index manifests, though these reference other manifests... And I don't see how two manifests could possible have the same manifest _within_ the same index? But fixed it just in case.