### PR TITLE
Restore/reimplement parts of the clustering layer

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.8"
 
       - name: Lint
         uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.8"
+          go-version: "1.25"
 
       - name: Lint
         uses: golangci/golangci-lint-action@v9

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -6,32 +6,32 @@ import (
 )
 
 type (
-	// Proposal defines an interface for creating proposal types.
-	// Implementers must return a stored random ID, but can include additional attributes.
-	// These attributes can be retrieved by asserting the Proposal back to its concrete type.
-	// TODO: Returning the payload as bytes in a Context or Body method makes way more sense.
-	// Body would be more like an HTTP request, while Context would be more like the rest of the Raft library.
-	Proposal interface {
-		ID() uint64
+	Operation string
+
+	Request struct {
+		ID   uint64
+		Op   Operation
+		Data []byte
+	}
+
+	Response struct {
+		Data []byte
+		Err  error
 	}
 
 	// HandlerFunc is a function that handles committing a proposal type.
-	// They typically type assert the given proposal into its concrete type,
-	// and process the payload by committing it to the state machine.
-	// HandlerFuncs can assume that they are never passed a Proposal of the wrong concrete type.
-	HandlerFunc func(p Proposal) error
+	HandlerFunc func(req Request) Response
 
-	// Proposer encapsulates making proposals to the cluster,
+	// Proposer encapsulates making proposals to a cluster,
 	// and handling those proposals once they are accepted.
 	Proposer interface {
 		// Consumers must call Handle() to register a function that commits
-		// proposals of a certain concrete type.
-		Handle(p Proposal, f HandlerFunc)
-		// Propose makes a proposal to the Raft log.
-		//
+		// proposals of a given operation type.
+		Handle(t Operation, f HandlerFunc)
+		// Propose makes a proposal to the cluster.
 		// Propose panics if a HandlerFunc has not been registered
 		// for the given proposal type using Handle.
-		Propose(p Proposal) error
+		Propose(req Request) Response
 	}
 
 	// Snapshotter wraps the basic Snapshot method.

--- a/cluster/fake_proposer.go
+++ b/cluster/fake_proposer.go
@@ -1,0 +1,37 @@
+package cluster
+
+import (
+	"fmt"
+	"log"
+	"math/rand/v2"
+)
+
+func NewFakeProposer() Proposer {
+	return &fakeProposer{
+		handlerFuncs: make(map[Operation]HandlerFunc),
+	}
+}
+
+// fakeProposer implements the Proposer interface without actually
+// making proposals to a  Great for testing.
+type fakeProposer struct {
+	handlerFuncs map[Operation]HandlerFunc
+}
+
+func (p *fakeProposer) Handle(t Operation, f HandlerFunc) {
+	if _, ok := p.handlerFuncs[t]; ok {
+		log.Fatalf("proposal type already registered: %s", t)
+	}
+	p.handlerFuncs[t] = f
+}
+
+func (p *fakeProposer) Propose(req Request) Response {
+	req.ID = rand.Uint64()
+
+	f, ok := p.handlerFuncs[req.Op]
+	if !ok {
+		panic(fmt.Sprintf("unknown proposal type received: %s", req.Op))
+	}
+
+	return f(req)
+}

--- a/cluster/fake_proposer.go
+++ b/cluster/fake_proposer.go
@@ -6,14 +6,14 @@ import (
 	"math/rand/v2"
 )
 
+// NewFakeProposer returns a Proposer that handles proposals without actually
+// submitting them to a cluster.
 func NewFakeProposer() Proposer {
 	return &fakeProposer{
 		handlerFuncs: make(map[Operation]HandlerFunc),
 	}
 }
 
-// fakeProposer implements the Proposer interface without actually
-// making proposals to a  Great for testing.
 type fakeProposer struct {
 	handlerFuncs map[Operation]HandlerFunc
 }

--- a/cluster/raft/proposer.go
+++ b/cluster/raft/proposer.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/gob"
 	"log"
-	"reflect"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -16,77 +16,105 @@ import (
 func newProposer(node raft.Node) *proposer {
 	return &proposer{
 		raft:         node,
-		handlerFuncs: make(map[reflect.Type]cluster.HandlerFunc),
-		errs:         newErrCs(),
+		handlerFuncs: make(map[cluster.Operation]cluster.HandlerFunc),
+		results:      newResultReporter(),
 	}
 }
 
 // proposer implements cluster.Proposer
 type proposer struct {
 	raft         raft.Node
-	handlerFuncs map[reflect.Type]cluster.HandlerFunc
-	errs         errCs
+	handlerFuncs map[cluster.Operation]cluster.HandlerFunc
+	results      resultReporter
 }
 
-func (p *proposer) Handle(proposal cluster.Proposal, f cluster.HandlerFunc) {
-	t := reflect.TypeOf(proposal)
+func (p *proposer) Handle(t cluster.Operation, f cluster.HandlerFunc) {
 	if _, ok := p.handlerFuncs[t]; ok {
-		log.Fatalf("proposal type already registered: %T", proposal)
+		log.Fatalf("proposal type already registered: %s", t)
 	}
-	p.handlerFuncs[reflect.TypeOf(proposal)] = f
-	gob.Register(proposal)
+	p.handlerFuncs[t] = f
 }
 
-// TODO: Pass a context here.
-func (p *proposer) Propose(proposal cluster.Proposal) error {
+func (p *proposer) Propose(req cluster.Request) cluster.Response {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
+	req.ID = rand.Uint64()
+
 	var buf bytes.Buffer
-	if err := gob.NewEncoder(&buf).Encode(&proposal); err != nil {
+	if err := gob.NewEncoder(&buf).Encode(&req); err != nil {
 		log.Panicf("failed to encode proposal: %s\n", err)
 	}
 
-	errC := p.errs.create(proposal.ID())
-	defer p.errs.delete(proposal.ID())
+	resultC := p.results.create(req.ID)
+	defer p.results.delete(req.ID)
 
-	// Propose blocks until accepted by the cluster.
-	err := p.raft.Propose(context.TODO(), buf.Bytes())
+	err := p.raft.Propose(ctx, buf.Bytes())
 	if err != nil {
-		return err
+		return cluster.Response{Err: err}
 	}
 
 	select {
-	// TODO: And wait for ctx.Done() instead of this dumb timeout.
-	case <-time.Tick(5 * time.Second):
-		panic("timed out")
-	case err := <-errC:
-		return err
+	case <-ctx.Done():
+		return cluster.Response{Err: ctx.Err()}
+	case result := <-resultC:
+		return result
 	}
 }
 
-// commit decodes the payload into a registered proposal type,
-// and calls its HandlerFunc.
-//
-// commit panics if a HandlerFunc has not been registered
-// for the given proposal type using Handle.
 func (p *proposer) commit(data []byte) {
 	buf := bytes.NewBuffer(data)
 
-	var proposal cluster.Proposal
-	err := gob.NewDecoder(buf).Decode(&proposal)
+	var req cluster.Request
+	err := gob.NewDecoder(buf).Decode(&req)
 	if err != nil {
 		log.Panicf("unable to decode as proposal: %s", err)
 	}
 
-	f, ok := p.handlerFuncs[reflect.TypeOf(proposal)]
+	f, ok := p.handlerFuncs[req.Op]
 	if !ok {
-		log.Panicf("unknown proposal type received: %T", proposal)
+		log.Panicf("unknown proposal type received: %s", req.Op)
 	}
 
-	err = f(proposal)
+	resp := f(req)
 
-	errC, ok := p.errs.get(proposal.ID())
+	result, ok := p.results.get(req.ID)
 	if ok {
-		errC <- err
+		result <- resp
 	}
+}
+
+func newResultReporter() resultReporter {
+	return resultReporter{
+		results: make(map[uint64]chan cluster.Response),
+	}
+}
+
+type resultReporter struct {
+	mu      sync.Mutex
+	results map[uint64]chan cluster.Response
+}
+
+func (r *resultReporter) create(id uint64) chan cluster.Response {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.results[id] = make(chan cluster.Response)
+	return r.results[id]
+}
+
+func (r *resultReporter) get(id uint64) (chan cluster.Response, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	resultC, err := r.results[id]
+	return resultC, err
+}
+
+func (r *resultReporter) delete(id uint64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	close(r.results[id])
+	delete(r.results, id)
 }
 
 func newErrCs() errCs {

--- a/cmd/cascade-registry/main.go
+++ b/cmd/cascade-registry/main.go
@@ -6,21 +6,37 @@ import (
 	"log"
 	"net/netip"
 	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 
+	"github.com/robinkb/cascade/cluster"
+	"github.com/robinkb/cascade/cluster/raft"
+	raftapi "github.com/robinkb/cascade/cluster/raft/api"
+	"github.com/robinkb/cascade/cluster/raft/qwal"
 	"github.com/robinkb/cascade/process"
 	"github.com/robinkb/cascade/registry"
 	registryapi "github.com/robinkb/cascade/registry/api/v2"
+	"github.com/robinkb/cascade/registry/store"
+	storeapi "github.com/robinkb/cascade/registry/store/api"
 	"github.com/robinkb/cascade/registry/store/driver/boltdb"
+	clusterstore "github.com/robinkb/cascade/registry/store/driver/cluster"
 	"github.com/robinkb/cascade/registry/store/driver/fs"
 	"github.com/robinkb/cascade/server"
 )
 
 var (
-	port int
+	port         int
+	raftId       int
+	raftHostPort string
+	raftPeers    string
 )
 
 func main() {
 	flag.IntVar(&port, "port", 5000, "port of the http server")
+	flag.IntVar(&raftId, "raft-id", 0, "internal id of raft node")
+	flag.StringVar(&raftHostPort, "raft-host", "", "host:port of this raft node")
+	flag.StringVar(&raftPeers, "raft-peers", "", "comma-seperated list of raft peers")
 	flag.Parse()
 
 	path, err := os.Getwd()
@@ -35,6 +51,54 @@ func main() {
 		log.Fatalf("failed to create metadata store backed by boltdb: %s", err)
 	}
 	blobs := fs.NewBlobStore(path)
+
+	if raftId != 0 {
+		addr := netip.MustParseAddrPort(raftHostPort)
+		srv := server.New(server.Options{
+			Name: "cluster-server",
+			Addr: addr,
+		})
+
+		hosts := strings.Split(raftPeers, ",")
+		peers := make([]cluster.Peer, len(hosts))
+		for i := range hosts {
+			parts := strings.Split(hosts[i], ":")
+			id, err := strconv.ParseUint(parts[0], 10, 64)
+			if err != nil {
+				log.Fatal(err)
+			}
+			host := strings.Join(parts[1:3], ":")
+			peers[i] = cluster.Peer{
+				ID:       id,
+				AddrPort: netip.MustParseAddrPort(host),
+			}
+		}
+
+		db, err := qwal.Open(filepath.Join(path, "raft"), nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+		storage, err := raft.NewDiskStorage(db, metadata)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer func() {
+			if err := storage.Close(); err != nil {
+				log.Println("error while closing raft storage:", err)
+			}
+		}()
+		restorer := store.NewRestorer(metadata, blobs)
+		node := raft.NewNode(uint64(raftId), addr, storage, restorer)
+		node.Bootstrap(peers...)
+
+		srv.Handle("/cluster/raft/", raftapi.New(node))
+		srv.Handle("/store/", storeapi.New(blobs))
+		mgr.Register(srv)
+		mgr.Register(node)
+
+		metadata = clusterstore.NewMetadataStore(node, metadata)
+		blobs = clusterstore.NewBlobStore(node, blobs)
+	}
 
 	srv := server.New(server.Options{
 		Name:          "oci-api",

--- a/registry/store/driver/cluster/blobs.go
+++ b/registry/store/driver/cluster/blobs.go
@@ -1,0 +1,297 @@
+package cluster
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/opencontainers/go-digest"
+
+	"github.com/robinkb/cascade/cluster"
+	"github.com/robinkb/cascade/registry/store"
+)
+
+const (
+	opPutBlob      = "B_PUT_BLOB"
+	opDeleteBlob   = "B_DELETE_BLOB"
+	opInitUpload   = "B_INIT_UPLOAD"
+	opAppendUpload = "B_APPEND_UPLOAD"
+	opCloseUpload  = "B_CLOSE_UPLOAD"
+	opDeleteUpload = "B_DELETE_UPLOAD"
+)
+
+func NewBlobStore(proposer cluster.Proposer, blobs store.Blobs) store.Blobs {
+	s := &blobStore{
+		Blobs:    blobs,
+		proposer: proposer,
+	}
+
+	proposer.Handle(opPutBlob, s.putBlob)
+	proposer.Handle(opDeleteBlob, s.deleteBlob)
+	proposer.Handle(opInitUpload, s.initUpload)
+	proposer.Handle(opAppendUpload, s.appendUpload)
+	proposer.Handle(opCloseUpload, s.closeUpload)
+	proposer.Handle(opDeleteUpload, s.deleteUpload)
+
+	return s
+}
+
+type blobStore struct {
+	store.Blobs
+	proposer cluster.Proposer
+}
+
+type putBlobRequest struct {
+	ID      digest.Digest
+	Content []byte
+}
+
+func (s *blobStore) PutBlob(id digest.Digest, content []byte) error {
+	req := &putBlobRequest{
+		ID:      id,
+		Content: content,
+	}
+	data, err := json.Marshal(&req)
+	if err != nil {
+		return err
+	}
+
+	resp := s.proposer.Propose(cluster.Request{
+		Op:   opPutBlob,
+		Data: data,
+	})
+
+	return resp.Err
+}
+
+func (s *blobStore) putBlob(req cluster.Request) (resp cluster.Response) {
+	var putBlobRequest putBlobRequest
+	err := json.Unmarshal(req.Data, &putBlobRequest)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	resp.Err = s.Blobs.PutBlob(putBlobRequest.ID, putBlobRequest.Content)
+	return
+}
+
+type deleteBlobRequest struct {
+	ID digest.Digest
+}
+
+func (s *blobStore) DeleteBlob(id digest.Digest) error {
+	req := &deleteBlobRequest{
+		ID: id,
+	}
+	data, err := json.Marshal(&req)
+	if err != nil {
+		return err
+	}
+
+	resp := s.proposer.Propose(cluster.Request{
+		Op:   opDeleteBlob,
+		Data: data,
+	})
+
+	return resp.Err
+}
+
+func (s *blobStore) deleteBlob(req cluster.Request) (resp cluster.Response) {
+	var deleteBlobRequest deleteBlobRequest
+	err := json.Unmarshal(req.Data, &deleteBlobRequest)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	resp.Err = s.Blobs.DeleteBlob(deleteBlobRequest.ID)
+	return
+}
+
+type initUploadRequest struct {
+	SessionID uuid.UUID
+}
+
+func (s *blobStore) InitUpload(id uuid.UUID) error {
+	req := initUploadRequest{
+		SessionID: id,
+	}
+	data, err := json.Marshal(&req)
+	if err != nil {
+		return err
+	}
+
+	resp := s.proposer.Propose(cluster.Request{
+		Op:   opInitUpload,
+		Data: data,
+	})
+
+	return resp.Err
+}
+
+func (s *blobStore) initUpload(req cluster.Request) (resp cluster.Response) {
+	var initUploadRequest initUploadRequest
+	err := json.Unmarshal(req.Data, &initUploadRequest)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	resp.Err = s.Blobs.InitUpload(initUploadRequest.SessionID)
+	return
+}
+
+func (s *blobStore) UploadWriter(id uuid.UUID) (io.WriteCloser, error) {
+	return &writer{
+		buf:       new(bytes.Buffer),
+		proposer:  s.proposer,
+		sessionId: id,
+	}, nil
+}
+
+const (
+	// TODO: Make this configurable?
+	writeBufferSize = 1 << 20
+)
+
+type writer struct {
+	proposer  cluster.Proposer
+	sessionId uuid.UUID
+	buf       *bytes.Buffer
+}
+
+func (w *writer) Write(p []byte) (n int, err error) {
+	if w.buf.Len()+len(p) > writeBufferSize {
+		n, err = w.flush()
+		if err != nil {
+			return n, err
+		}
+	}
+
+	return w.buf.Write(p)
+}
+
+type appendUploadRequest struct {
+	SessionID uuid.UUID
+	Chunk     []byte
+}
+
+func (w *writer) flush() (n int, err error) {
+	defer w.buf.Reset()
+
+	req := &appendUploadRequest{
+		SessionID: w.sessionId,
+		Chunk:     w.buf.Bytes(),
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		return 0, err
+	}
+
+	resp := w.proposer.Propose(cluster.Request{
+		Op:   opAppendUpload,
+		Data: data,
+	})
+
+	n = int(binary.LittleEndian.Uint64(resp.Data))
+	err = resp.Err
+	return
+}
+
+func (w *writer) Close() error {
+	_, err := w.flush()
+	return err
+}
+
+func (s *blobStore) appendUpload(req cluster.Request) (resp cluster.Response) {
+	var appendUploadRequest appendUploadRequest
+	err := json.Unmarshal(req.Data, &appendUploadRequest)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	w, err := s.Blobs.UploadWriter(appendUploadRequest.SessionID)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	buf := bytes.NewBuffer(appendUploadRequest.Chunk)
+	n, err := io.Copy(w, buf)
+	resp.Data = make([]byte, 8)
+	binary.LittleEndian.PutUint64(resp.Data, uint64(n))
+	resp.Err = err
+	return
+}
+
+type closeUploadRequest struct {
+	SessionID uuid.UUID
+	Digest    digest.Digest
+}
+
+func (s *blobStore) CloseUpload(id uuid.UUID, digest digest.Digest) error {
+	req := &closeUploadRequest{
+		SessionID: id,
+		Digest:    digest,
+	}
+	data, err := json.Marshal(&req)
+	if err != nil {
+		return err
+	}
+
+	resp := s.proposer.Propose(cluster.Request{
+		Op:   opCloseUpload,
+		Data: data,
+	})
+
+	return resp.Err
+}
+
+func (s *blobStore) closeUpload(req cluster.Request) (resp cluster.Response) {
+	var closeUploadRequest closeUploadRequest
+	err := json.Unmarshal(req.Data, &closeUploadRequest)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	resp.Err = s.Blobs.CloseUpload(closeUploadRequest.SessionID, closeUploadRequest.Digest)
+	return
+}
+
+type deleteUploadRequest struct {
+	SessionID uuid.UUID
+}
+
+func (s *blobStore) DeleteUpload(id uuid.UUID) error {
+	req := deleteUploadRequest{
+		SessionID: id,
+	}
+	data, err := json.Marshal(&req)
+	if err != nil {
+		return err
+	}
+
+	resp := s.proposer.Propose(cluster.Request{
+		Op:   opDeleteUpload,
+		Data: data,
+	})
+
+	return resp.Err
+}
+
+func (s *blobStore) deleteUpload(req cluster.Request) (resp cluster.Response) {
+	var deleteUploadRequest deleteUploadRequest
+	err := json.Unmarshal(req.Data, &deleteUploadRequest)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	resp.Err = s.Blobs.DeleteUpload(deleteUploadRequest.SessionID)
+	return
+}

--- a/registry/store/driver/cluster/blobs_test.go
+++ b/registry/store/driver/cluster/blobs_test.go
@@ -1,25 +1,21 @@
-package fs
+package cluster
 
 import (
-	"os"
 	"testing"
 
+	"github.com/robinkb/cascade/cluster"
 	"github.com/robinkb/cascade/registry/store"
+	"github.com/robinkb/cascade/registry/store/driver/inmemory"
 	storesuite "github.com/robinkb/cascade/registry/store/suite"
-	. "github.com/robinkb/cascade/testing" // nolint: staticcheck
 	"github.com/stretchr/testify/suite"
 )
 
 func TestBlobSuite(t *testing.T) {
 	suite.Run(t, &storesuite.BlobSuite{
 		Constructor: func(t *testing.T) store.Blobs {
-			tmp := t.TempDir()
-			t.Cleanup(func() {
-				err := os.RemoveAll(tmp)
-				AssertNoError(t, err).Require()
-			})
-
-			return NewBlobStore(tmp)
+			proposer := cluster.NewFakeProposer()
+			blobs := inmemory.NewBlobStore()
+			return NewBlobStore(proposer, blobs)
 		},
 	})
 }

--- a/registry/store/driver/cluster/metadata.go
+++ b/registry/store/driver/cluster/metadata.go
@@ -1,0 +1,465 @@
+package cluster
+
+import (
+	"encoding/json"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/opencontainers/go-digest"
+	"github.com/robinkb/cascade/cluster"
+	"github.com/robinkb/cascade/registry/store"
+)
+
+const (
+	opCreateRepository    = "M_CREATE_REPOSITORY"
+	opDeleteRepository    = "M_DELETE_REPOSITORY"
+	opPutBlobMeta         = "M_PUT_BLOB"
+	opDeleteBlobMeta      = "M_DELETE_BLOB"
+	opPutManifest         = "M_PUT_MANIFEST"
+	opDeleteManifest      = "M_DELETE_MANIFEST"
+	opPutTag              = "M_PUT_TAG"
+	opDeleteTag           = "M_DELETE_TAG"
+	opPutUploadSession    = "M_PUT_UPLOAD"
+	opDeleteUploadSession = "M_DELETE_UPLOAD"
+)
+
+func NewMetadataStore(proposer cluster.Proposer, meta store.Metadata) store.Metadata {
+	s := &metadataStore{
+		Metadata: meta,
+		proposer: proposer,
+	}
+
+	proposer.Handle(opCreateRepository, s.createRepository)
+	proposer.Handle(opDeleteRepository, s.deleteRepository)
+	proposer.Handle(opPutBlobMeta, s.putBlob)
+	proposer.Handle(opDeleteBlobMeta, s.deleteBlob)
+	proposer.Handle(opPutManifest, s.putManifest)
+	proposer.Handle(opDeleteManifest, s.deleteManifest)
+	proposer.Handle(opPutTag, s.putTag)
+	proposer.Handle(opDeleteTag, s.deleteTag)
+	proposer.Handle(opPutUploadSession, s.putUploadSession)
+	proposer.Handle(opDeleteUploadSession, s.deleteUploadSession)
+
+	return s
+}
+
+type metadataStore struct {
+	store.Metadata
+	proposer cluster.Proposer
+}
+
+func (m *metadataStore) CreateRepository(name string) (store.Repository, error) {
+	resp := m.proposer.Propose(cluster.Request{
+		Op:   opCreateRepository,
+		Data: []byte(name),
+	})
+	if resp.Err != nil {
+		return nil, resp.Err
+	}
+
+	return m.GetRepository(name)
+}
+
+func (m *metadataStore) createRepository(req cluster.Request) cluster.Response {
+	name := string(req.Data)
+
+	_, err := m.Metadata.CreateRepository(name)
+	return cluster.Response{
+		Err: err,
+	}
+}
+
+func (m *metadataStore) GetRepository(name string) (store.Repository, error) {
+	repo, err := m.Metadata.GetRepository(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return newRepository(repo, name, m.proposer)
+}
+
+func (m *metadataStore) DeleteRepository(name string) error {
+	resp := m.proposer.Propose(cluster.Request{
+		Op:   opDeleteRepository,
+		Data: []byte(name),
+	})
+	return resp.Err
+}
+
+func (m *metadataStore) deleteRepository(req cluster.Request) cluster.Response {
+	name := string(req.Data)
+
+	err := m.Metadata.DeleteRepository(name)
+	return cluster.Response{
+		Err: err,
+	}
+}
+
+func newRepository(repo store.Repository, name string, proposer cluster.Proposer) (store.Repository, error) {
+	return &repositoryStore{
+		Repository: repo,
+		name:       name,
+		proposer:   proposer,
+	}, nil
+}
+
+type repositoryStore struct {
+	store.Repository
+	proposer cluster.Proposer
+	name     string
+}
+
+type putBlobRequestParams struct {
+	Name string
+	ID   digest.Digest
+}
+
+func (r *repositoryStore) PutBlob(id digest.Digest) error {
+	req := &putBlobRequestParams{
+		Name: r.name,
+		ID:   id,
+	}
+	data, err := json.Marshal(&req)
+	if err != nil {
+		return err
+	}
+
+	resp := r.proposer.Propose(cluster.Request{
+		Op:   opPutBlobMeta,
+		Data: data,
+	})
+
+	return resp.Err
+}
+
+func (m *metadataStore) putBlob(req cluster.Request) (resp cluster.Response) {
+	var p putBlobRequestParams
+	err := json.Unmarshal(req.Data, &p)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	repo, err := m.Metadata.GetRepository(p.Name)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	resp.Err = repo.PutBlob(p.ID)
+	return
+}
+
+type deleteBlobMetaParams struct {
+	Name string
+	ID   digest.Digest
+}
+
+func (r *repositoryStore) DeleteBlob(id digest.Digest) error {
+	req := &deleteBlobMetaParams{
+		Name: r.name,
+		ID:   id,
+	}
+	data, err := json.Marshal(&req)
+	if err != nil {
+		return err
+	}
+
+	resp := r.proposer.Propose(cluster.Request{
+		Op:   opDeleteBlobMeta,
+		Data: data,
+	})
+
+	return resp.Err
+}
+
+func (m *metadataStore) deleteBlob(req cluster.Request) (resp cluster.Response) {
+	var p deleteBlobMetaParams
+	err := json.Unmarshal(req.Data, &p)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	repo, err := m.Metadata.GetRepository(p.Name)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	resp.Err = repo.DeleteBlob(p.ID)
+	return
+}
+
+type putManifestMetaParams struct {
+	Name string
+	ID   digest.Digest
+	Meta store.Manifest
+	Refs store.References
+}
+
+func (r *repositoryStore) PutManifest(id digest.Digest, meta store.Manifest, refs store.References) error {
+	req := &putManifestMetaParams{
+		Name: r.name,
+		ID:   id,
+		Meta: meta,
+		Refs: refs,
+	}
+	data, err := json.Marshal(&req)
+	if err != nil {
+		return err
+	}
+
+	resp := r.proposer.Propose(cluster.Request{
+		Op:   opPutManifest,
+		Data: data,
+	})
+
+	return resp.Err
+}
+
+func (m *metadataStore) putManifest(req cluster.Request) (resp cluster.Response) {
+	var p putManifestMetaParams
+	err := json.Unmarshal(req.Data, &p)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	repo, err := m.Metadata.GetRepository(p.Name)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	resp.Err = repo.PutManifest(p.ID, p.Meta, p.Refs)
+	return
+}
+
+type deleteManifestMetaParams struct {
+	Name string
+	ID   digest.Digest
+}
+
+func (r *repositoryStore) DeleteManifest(id digest.Digest) ([]digest.Digest, error) {
+	p := &deleteManifestMetaParams{
+		Name: r.name,
+		ID:   id,
+	}
+	data, err := json.Marshal(&p)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := r.proposer.Propose(cluster.Request{
+		Op:   opDeleteManifest,
+		Data: data,
+	})
+	if resp.Err != nil {
+		return nil, resp.Err
+	}
+
+	digests := make([]digest.Digest, 0)
+	err = json.Unmarshal(resp.Data, &digests)
+	return digests, err
+}
+
+func (m *metadataStore) deleteManifest(req cluster.Request) (resp cluster.Response) {
+	var p deleteManifestMetaParams
+	err := json.Unmarshal(req.Data, &p)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	repo, err := m.Metadata.GetRepository(p.Name)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	digests, err := repo.DeleteManifest(p.ID)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	resp.Data, resp.Err = json.Marshal(digests)
+	return
+}
+
+type putTagParams struct {
+	Name   string
+	Tag    string
+	Digest digest.Digest
+}
+
+func (r *repositoryStore) PutTag(tag string, digest digest.Digest) error {
+	req := &putTagParams{
+		Name:   r.name,
+		Tag:    tag,
+		Digest: digest,
+	}
+	data, err := json.Marshal(&req)
+	if err != nil {
+		return err
+	}
+
+	resp := r.proposer.Propose(cluster.Request{
+		Op:   opPutTag,
+		Data: data,
+	})
+
+	return resp.Err
+}
+
+func (m *metadataStore) putTag(req cluster.Request) (resp cluster.Response) {
+	var p putTagParams
+	err := json.Unmarshal(req.Data, &p)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	repo, err := m.Metadata.GetRepository(p.Name)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	resp.Err = repo.PutTag(p.Tag, p.Digest)
+	return
+}
+
+type deleteTagParams struct {
+	Name string
+	Tag  string
+}
+
+func (r *repositoryStore) DeleteTag(tag string) ([]digest.Digest, error) {
+	p := &deleteTagParams{
+		Name: r.name,
+		Tag:  tag,
+	}
+	data, err := json.Marshal(&p)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := r.proposer.Propose(cluster.Request{
+		Op:   opDeleteTag,
+		Data: data,
+	})
+	if resp.Err != nil {
+		return nil, resp.Err
+	}
+
+	digests := make([]digest.Digest, 0)
+	err = json.Unmarshal(resp.Data, &digests)
+	return digests, err
+}
+
+func (m *metadataStore) deleteTag(req cluster.Request) (resp cluster.Response) {
+	var p deleteTagParams
+	err := json.Unmarshal(req.Data, &p)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	repo, err := m.Metadata.GetRepository(p.Name)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	digests, err := repo.DeleteTag(p.Tag)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	resp.Data, resp.Err = json.Marshal(digests)
+	return
+}
+
+type putUploadSessionParams struct {
+	Name    string
+	Session *store.UploadSession
+}
+
+func (r *repositoryStore) PutUploadSession(session *store.UploadSession) error {
+	req := &putUploadSessionParams{
+		Name:    r.name,
+		Session: session,
+	}
+	data, err := json.Marshal(&req)
+	if err != nil {
+		return err
+	}
+
+	resp := r.proposer.Propose(cluster.Request{
+		Op:   opPutUploadSession,
+		Data: data,
+	})
+
+	return resp.Err
+}
+
+func (m *metadataStore) putUploadSession(req cluster.Request) (resp cluster.Response) {
+	var p putUploadSessionParams
+	err := json.Unmarshal(req.Data, &p)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	repo, err := m.Metadata.GetRepository(p.Name)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	resp.Err = repo.PutUploadSession(p.Session)
+	return
+}
+
+type deleteUploadSessionParams struct {
+	Name      string
+	SessionID uuid.UUID
+}
+
+func (r *repositoryStore) DeleteUploadSession(id uuid.UUID) error {
+	p := &deleteUploadSessionParams{
+		Name:      r.name,
+		SessionID: id,
+	}
+	data, err := json.Marshal(&p)
+	if err != nil {
+		return err
+	}
+
+	resp := r.proposer.Propose(cluster.Request{
+		Op:   opDeleteUploadSession,
+		Data: data,
+	})
+
+	return resp.Err
+}
+
+func (m *metadataStore) deleteUploadSession(req cluster.Request) (resp cluster.Response) {
+	var p deleteUploadSessionParams
+	err := json.Unmarshal(req.Data, &p)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	repo, err := m.Metadata.GetRepository(p.Name)
+	if err != nil {
+		resp.Err = err
+		return
+	}
+
+	resp.Err = repo.DeleteUploadSession(p.SessionID)
+	return
+}

--- a/registry/store/driver/cluster/metadata_test.go
+++ b/registry/store/driver/cluster/metadata_test.go
@@ -1,0 +1,21 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/robinkb/cascade/cluster"
+	"github.com/robinkb/cascade/registry/store"
+	"github.com/robinkb/cascade/registry/store/driver/inmemory"
+	storesuite "github.com/robinkb/cascade/registry/store/suite"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestMetadataSuite(t *testing.T) {
+	suite.Run(t, &storesuite.MetadataSuite{
+		Constructor: func(t *testing.T) store.Metadata {
+			proposer := cluster.NewFakeProposer()
+			meta := inmemory.NewMetadataStore()
+			return NewMetadataStore(proposer, meta)
+		},
+	})
+}

--- a/registry/store/driver/inmemory/blobs_test.go
+++ b/registry/store/driver/inmemory/blobs_test.go
@@ -1,25 +1,17 @@
-package fs
+package inmemory
 
 import (
-	"os"
 	"testing"
 
 	"github.com/robinkb/cascade/registry/store"
 	storesuite "github.com/robinkb/cascade/registry/store/suite"
-	. "github.com/robinkb/cascade/testing" // nolint: staticcheck
 	"github.com/stretchr/testify/suite"
 )
 
 func TestBlobSuite(t *testing.T) {
 	suite.Run(t, &storesuite.BlobSuite{
 		Constructor: func(t *testing.T) store.Blobs {
-			tmp := t.TempDir()
-			t.Cleanup(func() {
-				err := os.RemoveAll(tmp)
-				AssertNoError(t, err).Require()
-			})
-
-			return NewBlobStore(tmp)
+			return NewBlobStore()
 		},
 	})
 }

--- a/registry/store/suite/blobs.go
+++ b/registry/store/suite/blobs.go
@@ -1,0 +1,99 @@
+package suite
+
+import (
+	"bytes"
+	"io"
+	"slices"
+	"testing"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/opencontainers/go-digest"
+	"github.com/robinkb/cascade/registry/store"
+	. "github.com/robinkb/cascade/testing" // nolint: staticcheck
+	"github.com/stretchr/testify/suite"
+)
+
+type BlobStoreConstructor func(t *testing.T) store.Blobs
+
+type BlobSuite struct {
+	suite.Suite
+
+	Constructor BlobStoreConstructor
+}
+
+func (s *BlobSuite) TestBlobs() {
+	s.T().Run("creates and deletes blobs", func(t *testing.T) {
+		id, content := RandomBlob(64)
+		blobs := s.Constructor(t)
+
+		_, err := blobs.StatBlob(id)
+		AssertErrorIs(t, err, store.ErrBlobNotFound)
+
+		err = blobs.PutBlob(id, content)
+		AssertNoError(t, err)
+
+		got, err := blobs.GetBlob(id)
+		AssertNoError(t, err)
+		AssertSlicesEqual(t, got, content)
+
+		err = blobs.DeleteBlob(id)
+		AssertNoError(t, err)
+
+		_, err = blobs.StatBlob(id)
+		AssertErrorIs(t, err, store.ErrBlobNotFound)
+	})
+
+}
+
+func (s *BlobSuite) TestListBlobs() {
+	s.T().Run("lists all blobs", func(t *testing.T) {
+		count := 10
+		blobs := s.Constructor(t)
+
+		want := make([]digest.Digest, 0)
+		for range count {
+			id, content := RandomBlob(32)
+			err := blobs.PutBlob(id, content)
+			AssertNoError(t, err).Require()
+			want = append(want, id)
+		}
+
+		got := make([]digest.Digest, 0)
+		for id, err := range blobs.AllBlobs() {
+			AssertNoError(t, err)
+			got = append(got, id)
+		}
+
+		slices.Sort(want)
+		slices.Sort(got)
+
+		AssertSlicesEqual(t, got, want)
+		AssertEqual(t, len(got), count)
+	})
+}
+
+func (s *BlobSuite) TestUploads() {
+	s.T().Run("uploads a large blob", func(t *testing.T) {
+		id, content := RandomBlob(128 << 20)
+		blobs := s.Constructor(t)
+
+		sessionID, err := uuid.NewV7()
+		AssertNoError(t, err)
+
+		err = blobs.InitUpload(sessionID)
+		AssertNoError(t, err)
+
+		w, err := blobs.UploadWriter(sessionID)
+		AssertNoError(t, err)
+
+		// TODO: This calls Write() only once with the entire blob.
+		// Should find out how to make it call in 32kB chunks for a more effective test.
+		r := bytes.NewBuffer(content)
+		n, err := io.Copy(w, r)
+		AssertNoError(t, err)
+		AssertEqual(t, n, int64(len(content)))
+
+		err = blobs.CloseUpload(sessionID, id)
+		AssertNoError(t, err)
+	})
+}

--- a/registry/store/suite/metadata.go
+++ b/registry/store/suite/metadata.go
@@ -1107,7 +1107,7 @@ func (s *MetadataSuite) TestUploadSessions() {
 
 	session := &store.UploadSession{
 		ID:        RandomUUID(),
-		StartDate: time.Now().Round(0),
+		StartDate: time.Now().UTC().Round(0),
 		HashState: RandomBytes(8),
 	}
 

--- a/testing/assert.go
+++ b/testing/assert.go
@@ -219,7 +219,7 @@ func AssertDeepEqual(t testing.TB, got, want any) *Result {
 	t.Helper()
 
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("structs are not equal;\ngot:\n%+v\nwant:\n%+v", got, want)
+		t.Errorf("structs are not equal;\ngot:\n%#v\nwant:\n%#v", got, want)
 		return &Result{t, false}
 	}
 

--- a/testing/assert.go
+++ b/testing/assert.go
@@ -219,7 +219,7 @@ func AssertDeepEqual(t testing.TB, got, want any) *Result {
 	t.Helper()
 
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("structs are not equal;\ngot:\n%#v\nwant:\n%#v", got, want)
+		t.Errorf("structs are not equal;\ngot:\n%+v\nwant:\n%+v", got, want)
 		return &Result{t, false}
 	}
 

--- a/testing/mock/raft/node.go
+++ b/testing/mock/raft/node.go
@@ -235,8 +235,8 @@ func (_c *Node_Bootstrap_Call) RunAndReturn(run func(peers ...cluster.Peer)) *No
 }
 
 // Handle provides a mock function for the type Node
-func (_mock *Node) Handle(p cluster.Proposal, f cluster.HandlerFunc) {
-	_mock.Called(p, f)
+func (_mock *Node) Handle(t cluster.Operation, f cluster.HandlerFunc) {
+	_mock.Called(t, f)
 	return
 }
 
@@ -246,17 +246,17 @@ type Node_Handle_Call struct {
 }
 
 // Handle is a helper method to define mock.On call
-//   - p cluster.Proposal
+//   - t cluster.ProposalType
 //   - f cluster.HandlerFunc
-func (_e *Node_Expecter) Handle(p interface{}, f interface{}) *Node_Handle_Call {
-	return &Node_Handle_Call{Call: _e.mock.On("Handle", p, f)}
+func (_e *Node_Expecter) Handle(t interface{}, f interface{}) *Node_Handle_Call {
+	return &Node_Handle_Call{Call: _e.mock.On("Handle", t, f)}
 }
 
-func (_c *Node_Handle_Call) Run(run func(p cluster.Proposal, f cluster.HandlerFunc)) *Node_Handle_Call {
+func (_c *Node_Handle_Call) Run(run func(t cluster.Operation, f cluster.HandlerFunc)) *Node_Handle_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 cluster.Proposal
+		var arg0 cluster.Operation
 		if args[0] != nil {
-			arg0 = args[0].(cluster.Proposal)
+			arg0 = args[0].(cluster.Operation)
 		}
 		var arg1 cluster.HandlerFunc
 		if args[1] != nil {
@@ -275,7 +275,7 @@ func (_c *Node_Handle_Call) Return() *Node_Handle_Call {
 	return _c
 }
 
-func (_c *Node_Handle_Call) RunAndReturn(run func(p cluster.Proposal, f cluster.HandlerFunc)) *Node_Handle_Call {
+func (_c *Node_Handle_Call) RunAndReturn(run func(t cluster.Operation, f cluster.HandlerFunc)) *Node_Handle_Call {
 	_c.Run(run)
 	return _c
 }
@@ -369,18 +369,18 @@ func (_c *Node_NodeID_Call) RunAndReturn(run func() uint64) *Node_NodeID_Call {
 }
 
 // Propose provides a mock function for the type Node
-func (_mock *Node) Propose(p cluster.Proposal) error {
-	ret := _mock.Called(p)
+func (_mock *Node) Propose(req cluster.Request) cluster.Response {
+	ret := _mock.Called(req)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Propose")
 	}
 
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(cluster.Proposal) error); ok {
-		r0 = returnFunc(p)
+	var r0 cluster.Response
+	if returnFunc, ok := ret.Get(0).(func(cluster.Request) cluster.Response); ok {
+		r0 = returnFunc(req)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(cluster.Response)
 	}
 	return r0
 }
@@ -391,16 +391,16 @@ type Node_Propose_Call struct {
 }
 
 // Propose is a helper method to define mock.On call
-//   - p cluster.Proposal
-func (_e *Node_Expecter) Propose(p interface{}) *Node_Propose_Call {
-	return &Node_Propose_Call{Call: _e.mock.On("Propose", p)}
+//   - req cluster.Request
+func (_e *Node_Expecter) Propose(req interface{}) *Node_Propose_Call {
+	return &Node_Propose_Call{Call: _e.mock.On("Propose", req)}
 }
 
-func (_c *Node_Propose_Call) Run(run func(p cluster.Proposal)) *Node_Propose_Call {
+func (_c *Node_Propose_Call) Run(run func(req cluster.Request)) *Node_Propose_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 cluster.Proposal
+		var arg0 cluster.Request
 		if args[0] != nil {
-			arg0 = args[0].(cluster.Proposal)
+			arg0 = args[0].(cluster.Request)
 		}
 		run(
 			arg0,
@@ -409,12 +409,12 @@ func (_c *Node_Propose_Call) Run(run func(p cluster.Proposal)) *Node_Propose_Cal
 	return _c
 }
 
-func (_c *Node_Propose_Call) Return(err error) *Node_Propose_Call {
-	_c.Call.Return(err)
+func (_c *Node_Propose_Call) Return(response cluster.Response) *Node_Propose_Call {
+	_c.Call.Return(response)
 	return _c
 }
 
-func (_c *Node_Propose_Call) RunAndReturn(run func(p cluster.Proposal) error) *Node_Propose_Call {
+func (_c *Node_Propose_Call) RunAndReturn(run func(req cluster.Request) cluster.Response) *Node_Propose_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Changed the `cluster.Proposer` interface to be more flexible so that it can return more than just an error. Then re-implemented the `cluster` store drivers using it. The initial plan was to wrap the Domain interfaces (`registry.Service`  and `repository.Service`) because it would result in fewer `cluster.Proposer` calls/Raft messages. However, I couldn't figure out a way to properly wrap `repository.Service.AppendUpload` while keeping it efficient. Wrapping that method would result in reading and writing from the metadata store for every single message that is part of a streaming upload. Excessive.

The `store.Blobs` and `store.Metadata`  interfaces are much simpler, and easier to wrap. Plus, the test suites in the `store` package made it easy to test the implementation in a very focused way.

Started building a test suite `store.Blobs` as well to help develop this feature. I should expand it, because pushing a blob to a Cascade cluster shows some panics.

