### PR TITLE
Restore reconciliation and fix putting a manifest twice

### DIFF
--- a/cmd/cascade-registry/main.go
+++ b/cmd/cascade-registry/main.go
@@ -106,7 +106,7 @@ func main() {
 		LoggerEnabled: true,
 	})
 
-	service := registry.NewService(metadata, blobs)
+	service := registry.New(metadata, blobs)
 	srv.Handle("/", registryapi.New(service))
 
 	mgr.Register(srv)

--- a/registry/api/v2/handler_test.go
+++ b/registry/api/v2/handler_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestRoot(t *testing.T) {
 	server := New(
-		registry.NewService(
+		registry.New(
 			inmemory.NewMetadataStore(),
 			inmemory.NewBlobStore(),
 		),

--- a/registry/service.go
+++ b/registry/service.go
@@ -16,7 +16,7 @@ type (
 	}
 )
 
-func NewService(meta store.Metadata, blobs store.Blobs) Service {
+func New(meta store.Metadata, blobs store.Blobs) Service {
 	return &registryService{
 		meta:  meta,
 		blobs: blobs,

--- a/registry/service_test.go
+++ b/registry/service_test.go
@@ -36,7 +36,7 @@ func TestRepository(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		service := NewService(tt.constructor())
+		service := New(tt.constructor())
 
 		t.Run(tt.description, func(t *testing.T) {
 			t.Run("Create a repository, do something with it, and delete it", func(t *testing.T) {

--- a/registry/store/driver/boltdb/metadata_types.go
+++ b/registry/store/driver/boltdb/metadata_types.go
@@ -116,10 +116,10 @@ func (o manifests) manifest(id digest.Digest) manifest {
 }
 
 func (o manifests) addManifest(id digest.Digest, meta store.Manifest, refs store.References) manifest {
-	b, err := o.b.CreateBucket([]byte(id))
+	b, err := o.b.CreateBucketIfNotExists([]byte(id))
 	must(err)
 	for _, bucket := range manifestBuckets {
-		must(b.CreateBucket(bucket))
+		must(b.CreateBucketIfNotExists(bucket))
 	}
 
 	buf := new(bytes.Buffer)

--- a/registry/store/driver/inmemory/reconciler_test.go
+++ b/registry/store/driver/inmemory/reconciler_test.go
@@ -1,20 +1,20 @@
 package inmemory
 
-// import (
-// 	"testing"
+import (
+	"testing"
 
-// 	"github.com/robinkb/cascade/registry/store"
-// 	storesuite "github.com/robinkb/cascade/registry/store/suite"
-// 	"github.com/stretchr/testify/suite"
-// )
+	"github.com/robinkb/cascade/registry/store"
+	storesuite "github.com/robinkb/cascade/registry/store/suite"
+	"github.com/stretchr/testify/suite"
+)
 
-// func TestReconcilerSuite(t *testing.T) {
-// 	suite.Run(t, &storesuite.ReconcilerSuite{
-// 		MetadataStoreConstructor: func() store.Metadata {
-// 			return NewMetadataStore()
-// 		},
-// 		BlobStoreConstructor: func() store.Blobs {
-// 			return NewBlobStore()
-// 		},
-// 	})
-// }
+func TestReconcilerSuite(t *testing.T) {
+	suite.Run(t, &storesuite.ReconcilerSuite{
+		MetadataStoreConstructor: func(t *testing.T) store.Metadata {
+			return NewMetadataStore()
+		},
+		BlobStoreConstructor: func(t *testing.T) store.Blobs {
+			return NewBlobStore()
+		},
+	})
+}

--- a/registry/store/reconciler.go
+++ b/registry/store/reconciler.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -33,33 +34,28 @@ func (r *restorer) Restore(rd io.Reader, peer cluster.Peer) error {
 }
 
 func Reconcile(meta Metadata, blobs Blobs, src BlobReader) error {
-	// digests, err := meta.ListBlobs()
-	// if err != nil {
-	// 	return err
-	// }
+	for id := range meta.Blobs() {
+		if _, err := blobs.StatBlob(id); err != nil {
+			if errors.Is(err, ErrBlobNotFound) {
+				r, err := src.BlobReader(id)
+				if err != nil {
+					return err
+				}
 
-	// for _, d := range digests {
-	// 	if _, err := blobs.StatBlob(d); err != nil {
-	// 		if errors.Is(err, ErrNotFound) {
-	// 			r, err := src.BlobReader(d)
-	// 			if err != nil {
-	// 				return err
-	// 			}
+				w, err := blobs.BlobWriter(id)
+				if err != nil {
+					return err
+				}
 
-	// 			w, err := blobs.BlobWriter(d)
-	// 			if err != nil {
-	// 				return err
-	// 			}
-
-	// 			_, err = io.Copy(w, r)
-	// 			if err != nil {
-	// 				return err
-	// 			}
-	// 		} else {
-	// 			return err
-	// 		}
-	// 	}
-	// }
+				_, err = io.Copy(w, r)
+				if err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
+		}
+	}
 
 	return nil
 }

--- a/registry/store/suite/metadata.go
+++ b/registry/store/suite/metadata.go
@@ -448,6 +448,16 @@ func (s *MetadataSuite) TestManifests() {
 		AssertErrorIs(t, err, store.ErrManifestNotFound)
 	})
 
+	s.T().Run("update an existing manifest", func(t *testing.T) {
+		repo := s.RepositoryConstructor(t)
+		id := RandomDigest()
+
+		err := repo.PutManifest(id, store.Manifest{}, store.References{})
+		AssertNoError(t, err)
+		err = repo.PutManifest(id, store.Manifest{}, store.References{})
+		AssertNoError(t, err)
+	})
+
 	s.T().Run("deletes a referenced manifest config blob", func(t *testing.T) {
 		repo := s.RepositoryConstructor(t)
 		configDigest, manifestDigest := RandomDigest(), RandomDigest()

--- a/registry/store/suite/reconciler.go
+++ b/registry/store/suite/reconciler.go
@@ -1,60 +1,58 @@
 package suite
 
-// import (
-// 	"slices"
-// 	"testing"
+import (
+	"slices"
+	"testing"
 
-// 	"github.com/opencontainers/go-digest"
-// 	"github.com/robinkb/cascade/registry/store"
-// 	. "github.com/robinkb/cascade/testing" // nolint: staticcheck
-// 	"github.com/stretchr/testify/suite"
-// )
+	"github.com/opencontainers/go-digest"
+	"github.com/robinkb/cascade/registry/store"
+	. "github.com/robinkb/cascade/testing" // nolint: staticcheck
+	"github.com/stretchr/testify/suite"
+)
 
-// type BlobStoreConstructor func() store.Blobs
+type ReconcilerSuite struct {
+	suite.Suite
 
-// type ReconcilerSuite struct {
-// 	suite.Suite
+	MetadataStoreConstructor MetadataStoreConstructor
+	BlobStoreConstructor     BlobStoreConstructor
+}
 
-// 	MetadataStoreConstructor MetadataStoreConstructor
-// 	BlobStoreConstructor     BlobStoreConstructor
-// }
+func (s *ReconcilerSuite) TestReconcile() {
+	s.T().Run("reconciles from full source into empty destination", func(t *testing.T) {
+		meta := s.MetadataStoreConstructor(t)
+		blobs := s.BlobStoreConstructor(t)
+		src := s.BlobStoreConstructor(t)
+		count := 10
 
-// func (s *ReconcilerSuite) TestReconcile() {
-// 	s.T().Run("reconciles from full source into empty destination", func(t *testing.T) {
-// 		meta := s.MetadataStoreConstructor()
-// 		blobs := s.BlobStoreConstructor()
-// 		src := s.BlobStoreConstructor()
-// 		count := 10
+		name := RandomName()
+		repo, err := meta.CreateRepository(name)
+		AssertNoError(t, err).Require()
 
-// 		name := RandomName()
-// 		err := meta.CreateRepository(name)
-// 		AssertNoError(t, err).Require()
+		want := make([]digest.Digest, 0)
+		for range count {
+			id, content := RandomBlob(32)
+			want = append(want, id)
 
-// 		want := make([]digest.Digest, 0)
-// 		for range count {
-// 			id, content := RandomBlob(32)
-// 			want = append(want, id)
+			err := repo.PutBlob(id)
+			AssertNoError(t, err).Require()
 
-// 			err := meta.PutBlob(name, id)
-// 			AssertNoError(t, err).Require()
+			err = src.PutBlob(id, content)
+			AssertNoError(t, err).Require()
+		}
 
-// 			err = src.PutBlob(id, content)
-// 			AssertNoError(t, err).Require()
-// 		}
+		err = store.Reconcile(meta, blobs, src)
+		AssertNoError(t, err)
 
-// 		err = store.Reconcile(meta, blobs, src)
-// 		AssertNoError(t, err)
+		got := make([]digest.Digest, 0)
+		for id, err := range blobs.AllBlobs() {
+			AssertNoError(t, err)
+			got = append(got, id)
+		}
 
-// 		got := make([]digest.Digest, 0)
-// 		for id, err := range blobs.AllBlobs() {
-// 			AssertNoError(t, err)
-// 			got = append(got, id)
-// 		}
+		slices.Sort(got)
+		slices.Sort(want)
 
-// 		slices.Sort(got)
-// 		slices.Sort(want)
-
-// 		AssertEqual(t, len(got), count)
-// 		AssertSlicesEqual(t, got, want)
-// 	})
-// }
+		AssertEqual(t, len(got), count)
+		AssertSlicesEqual(t, got, want)
+	})
+}

--- a/testing/conformance/content_discovery_test.go
+++ b/testing/conformance/content_discovery_test.go
@@ -17,7 +17,7 @@ import (
 func TestContentDiscovery(t *testing.T) {
 	metadata := inmemory.NewMetadataStore()
 	blobs := inmemory.NewBlobStore()
-	service := registry.NewService(metadata, blobs)
+	service := registry.New(metadata, blobs)
 	srv := v2.New(service)
 
 	t.Run("Listing Tags", func(t *testing.T) {

--- a/testing/conformance/content_management_test.go
+++ b/testing/conformance/content_management_test.go
@@ -14,7 +14,7 @@ import (
 func TestContentManagement(t *testing.T) {
 	metadata := inmemory.NewMetadataStore()
 	blobs := inmemory.NewBlobStore()
-	service := registry.NewService(metadata, blobs)
+	service := registry.New(metadata, blobs)
 	srv := v2.New(service)
 
 	t.Run("Deleting tags", func(t *testing.T) {

--- a/testing/conformance/pull_test.go
+++ b/testing/conformance/pull_test.go
@@ -15,7 +15,7 @@ import (
 func TestPull(t *testing.T) {
 	metadata := inmemory.NewMetadataStore()
 	blobs := inmemory.NewBlobStore()
-	service := registry.NewService(metadata, blobs)
+	service := registry.New(metadata, blobs)
 	srv := v2.New(service)
 
 	t.Run("Pulling manifests", func(t *testing.T) {

--- a/testing/conformance/push_test.go
+++ b/testing/conformance/push_test.go
@@ -17,7 +17,7 @@ import (
 func TestPush(t *testing.T) {
 	metadata := inmemory.NewMetadataStore()
 	blobs := inmemory.NewBlobStore()
-	service := registry.NewService(metadata, blobs)
+	service := registry.New(metadata, blobs)
 	srv := v2.New(service)
 
 	t.Run("Pushing blobs", func(t *testing.T) {


### PR DESCRIPTION
This is simply restoring the reconciler that was already there. Issue #128 will improve its reliability, and I will take that opportunity to write more tests, too.