### PR TITLE
Support deleting a tagged manifest

### DIFF
--- a/registry/api/v2/ext_catalog_test.go
+++ b/registry/api/v2/ext_catalog_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestListRepositories(t *testing.T) {
-	names := RandomNames(20)
+	names := RandomNameN(20)
 
 	t.Run("Listing tags returns 200", func(t *testing.T) {
 		svc := mock.NewService(t)

--- a/registry/api/v2/tags_test.go
+++ b/registry/api/v2/tags_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestListTags(t *testing.T) {
 	name := RandomName()
-	tags := RandomTags(20)
+	tags := RandomVersionN(20)
 
 	t.Run("Listing tags returns 200", func(t *testing.T) {
 		repo := mock.NewService(t)

--- a/registry/repository/manifest_test.go
+++ b/registry/repository/manifest_test.go
@@ -107,9 +107,6 @@ func TestDeleteManifest(t *testing.T) {
 
 		repo := mockstore.NewRepository(t)
 		repo.EXPECT().
-			GetManifest(manifest.Digest).
-			Return(store.Manifest{}, nil)
-		repo.EXPECT().
 			DeleteManifest(manifest.Digest).
 			Return(manifest.LayersAsDigests(), nil)
 
@@ -123,6 +120,38 @@ func TestDeleteManifest(t *testing.T) {
 		svc := New(blobs, repo)
 		err := svc.DeleteManifest(manifest.Digest.String())
 		AssertNoError(t, err)
+	})
+
+	t.Run("deduplicates deleted blobs before deletion", func(t *testing.T) {
+		layerDigest := RandomDigest()
+		digests := []digest.Digest{layerDigest, layerDigest, layerDigest}
+		manifestDigest := RandomDigest()
+
+		repo := mockstore.NewRepository(t)
+		repo.EXPECT().
+			DeleteManifest(manifestDigest).
+			Return(digests, nil)
+
+		blobs := mockstore.NewBlobs(t)
+		blobs.EXPECT().
+			DeleteBlob(layerDigest).
+			Return(nil).Once()
+
+		svc := New(blobs, repo)
+		err := svc.DeleteManifest(manifestDigest.String())
+		AssertNoError(t, err)
+	})
+
+	t.Run("deleting unknown manifest returns ErrManifestUnknown", func(t *testing.T) {
+		id := RandomDigest()
+		repo := mockstore.NewRepository(t)
+		repo.EXPECT().
+			DeleteManifest(id).
+			Return(nil, ErrManifestUnknown)
+
+		svc := New(nil, repo)
+		err := svc.DeleteManifest(id.String())
+		AssertErrorIs(t, err, ErrManifestUnknown)
 	})
 }
 

--- a/registry/repository/manifests.go
+++ b/registry/repository/manifests.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log"
+	"slices"
 	"sync"
 
 	"github.com/opencontainers/go-digest"
@@ -157,15 +158,13 @@ func (s *repositoryService) DeleteManifest(id string) error {
 		return ErrManifestUnknown
 	}
 
-	_, err = s.repo.GetManifest(digest)
-	if err != nil {
-		return ErrManifestUnknown
-	}
-
 	deleted, err := s.repo.DeleteManifest(digest)
 	if err != nil {
 		return err
 	}
+
+	slices.Sort(deleted)
+	deleted = slices.Compact(deleted)
 
 	var wg sync.WaitGroup
 	for _, id := range deleted {

--- a/registry/repository/tags.go
+++ b/registry/repository/tags.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"errors"
 	"log"
+	"slices"
 	"sync"
 
 	"github.com/opencontainers/go-digest"
@@ -48,6 +49,9 @@ func (s *repositoryService) DeleteTag(tag string) error {
 	if err != nil {
 		return err
 	}
+
+	slices.Sort(deleted)
+	deleted = slices.Compact(deleted)
 
 	var wg sync.WaitGroup
 	for _, id := range deleted {

--- a/registry/repository/tags_test.go
+++ b/registry/repository/tags_test.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"testing"
 
+	"github.com/opencontainers/go-digest"
 	. "github.com/robinkb/cascade/testing" // nolint: staticcheck
 	mockstore "github.com/robinkb/cascade/testing/mock/store"
 )
@@ -24,6 +25,26 @@ func TestDeleteTags(t *testing.T) {
 				DeleteBlob(id).
 				Return(nil)
 		}
+
+		svc := New(blobs, repo)
+		err := svc.DeleteTag(tag)
+		AssertNoError(t, err)
+	})
+
+	t.Run("deduplicates deleted blobs before deletion", func(t *testing.T) {
+		id := RandomDigest()
+		digests := []digest.Digest{id, id, id}
+		tag := RandomVersion()
+
+		repo := mockstore.NewRepository(t)
+		repo.EXPECT().
+			DeleteTag(tag).
+			Return(digests, nil)
+
+		blobs := mockstore.NewBlobs(t)
+		blobs.EXPECT().
+			DeleteBlob(id).
+			Return(nil).Once()
 
 		svc := New(blobs, repo)
 		err := svc.DeleteTag(tag)

--- a/registry/store/driver/boltdb/metadata.go
+++ b/registry/store/driver/boltdb/metadata.go
@@ -435,6 +435,11 @@ func (r *repositoryStore) deleteManifest(tx *bolt.Tx, id digest.Digest) ([]diges
 		deleted = append(deleted, digests...)
 	}
 
+	tags := repo.tags()
+	for tag := range manifest.tags() {
+		tags.removeTag(tag)
+	}
+
 	manifests.removeManifest(id)
 
 	blobs.blob(id).removeOwner(id)

--- a/registry/store/driver/boltdb/metadata_types.go
+++ b/registry/store/driver/boltdb/metadata_types.go
@@ -160,9 +160,16 @@ func (o manifest) references() (refs store.References) {
 func (o manifest) referrers() iter.Seq[digest.Digest] {
 	return func(yield func(digest.Digest) bool) {
 		must(o.b.Bucket(_REFERRERS).ForEach(func(id, _ []byte) error {
-			if !yield(digest.Digest(id)) {
-				return nil
-			}
+			yield(digest.Digest(id))
+			return nil
+		}))
+	}
+}
+
+func (o manifest) tags() iter.Seq[string] {
+	return func(yield func(string) bool) {
+		must(o.b.Bucket(_TAGS).ForEach(func(tag, _ []byte) error {
+			yield(string(tag))
 			return nil
 		}))
 	}
@@ -193,8 +200,7 @@ func (o manifest) removeTagOwner(tag string) {
 }
 
 func (o manifest) hasOwners() bool {
-	return o.b.Bucket(_MANIFESTS).Inspect().KeyN != 0 ||
-		o.b.Bucket(_TAGS).Inspect().KeyN != 0
+	return o.b.Bucket(_MANIFESTS).Inspect().KeyN != 0
 }
 
 type tags struct {

--- a/registry/store/driver/inmemory/metadata.go
+++ b/registry/store/driver/inmemory/metadata.go
@@ -260,7 +260,7 @@ func (r *repositoryStore) DeleteManifest(id digest.Digest) ([]digest.Digest, err
 		return nil, store.ErrManifestNotFound
 	}
 
-	if len(manifest.Manifests) != 0 || len(manifest.Tags) != 0 {
+	if len(manifest.Manifests) != 0 {
 		return nil, fmt.Errorf("%w: %s", store.ErrManifestInUse, id)
 	}
 
@@ -315,6 +315,10 @@ func (r *repositoryStore) DeleteManifest(id digest.Digest) ([]digest.Digest, err
 			return deleted, err
 		}
 		deleted = append(deleted, digests...)
+	}
+
+	for tag := range manifest.Tags {
+		delete(r.repo.Tags, tag)
 	}
 
 	delete(r.repo.Manifests, id)

--- a/registry/store/suite/metadata.go
+++ b/registry/store/suite/metadata.go
@@ -979,17 +979,24 @@ func (s *MetadataSuite) TestTags() {
 		AssertErrorIs(t, err, store.ErrManifestNotFound)
 	})
 
-	s.T().Run("deleting tagged manifest returns ErrManifestInUse", func(t *testing.T) {
+	s.T().Run("deleting tagged manifest deletes its tags", func(t *testing.T) {
 		repo := s.RepositoryConstructor(t)
-		digest, tag := RandomDigest(), RandomVersion()
+		digest, tags := RandomDigest(), RandomVersionN(3)
 
 		err := repo.PutManifest(digest, store.Manifest{}, store.References{})
 		AssertNoError(t, err)
-		err = repo.PutTag(tag, digest)
-		AssertNoError(t, err)
+		for _, tag := range tags {
+			err = repo.PutTag(tag, digest)
+			AssertNoError(t, err)
+		}
 
 		_, err = repo.DeleteManifest(digest)
-		AssertErrorIs(t, err, store.ErrManifestInUse)
+		AssertNoError(t, err)
+
+		for _, tag := range tags {
+			_, err = repo.GetTag(tag)
+			AssertErrorIs(t, err, store.ErrTagNotFound)
+		}
 	})
 
 	s.T().Run("deleting unknown tag returns ErrTagNotFound", func(t *testing.T) {

--- a/testing/conformance/content_discovery_test.go
+++ b/testing/conformance/content_discovery_test.go
@@ -23,7 +23,7 @@ func TestContentDiscovery(t *testing.T) {
 	t.Run("Listing Tags", func(t *testing.T) {
 		repository := RandomName()
 		_, _, content := RandomManifest()
-		tags := RandomTags(50)
+		tags := RandomVersionN(50)
 
 		client := testclient.NewForHandler(t, srv)
 		for _, tag := range tags {

--- a/testing/random.go
+++ b/testing/random.go
@@ -30,7 +30,7 @@ func RandomName() string {
 	return b.String()
 }
 
-func RandomNames(n int) []string {
+func RandomNameN(n int) []string {
 	names := make([]string, n)
 	for i := range n {
 		names[i] = RandomName()
@@ -136,10 +136,10 @@ func RandomVersion() string {
 	return fmt.Sprintf("v%d.%d.%d", major, minor, patch)
 }
 
-// RandomTags generates a slice filled with random, unique versions.
+// RandomVersionN generates a slice filled with random, unique versions.
 // The returned slice is unsorted, because some tests require random input
 // to ensure that the registry is properly sorting tags internally.
-func RandomTags(count int) (tags []string) {
+func RandomVersionN(count int) (tags []string) {
 	var version string
 	for range count {
 		for {


### PR DESCRIPTION
Resolves #137.

Most tools seem to work this way, so let's allow both. I already returned a slice of deleted digests on manifest deletion, so all that was necessary was an adjustment in the ownership checking. Deleting a manifest by digest also deletes all tags referring to it. 

Confirmed that `skopeo` and `registry-ui` both work as expected with this patch :)