### PR TITLE
Separate out replaying `qwal.DB` into a method and support ReplayHook

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,9 @@
 version: "2"
 linters:
   exclusions:
+    paths:
+      - cluster/raft/qwal/example_test.go
+      - cluster/raft/qwal/example_dump_test.go
     rules:
       - linters:
           - staticcheck

--- a/cluster/raft/qwal/db.go
+++ b/cluster/raft/qwal/db.go
@@ -54,49 +54,6 @@ func Open(dir string, opts *Options) (DB, error) {
 		}
 	}
 
-	logFiles, err := discoverLogFiles(dir)
-	if err != nil {
-		return nil, err
-	}
-
-	for i, name := range logFiles {
-		name := filepath.Join(db.dir, name)
-		log, err := openLogFile(name)
-		if err != nil {
-			return nil, err
-		}
-
-		// Read the entire log to rebuild our in-memory inventory of records.
-		for record := range log.All() {
-			offset, size := log.Pointer()
-
-			db.inventory.Add(record.Type, pointer{
-				Log:    log.ID,
-				Offset: offset,
-				Size:   size,
-			})
-		}
-
-		// Lock all but the last log file.
-		if i != len(logFiles)-1 {
-			if err := log.Lock(); err != nil {
-				return nil, err
-			}
-		}
-
-		db.logs = append(db.logs, log)
-		db.sequence++
-	}
-
-	if len(db.logs) == 0 {
-		_, err := db.newLog()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	db.offset = uint64(db.logs[0].ID)
-
 	return &db, nil
 }
 
@@ -124,6 +81,11 @@ type db struct {
 	// organized by type. It grows when appending Records to the DB,
 	// and shrinks when Logs in the DB are compacted.
 	inventory *inventory
+	// replayed tracks if the DB has been replayed.
+	replayed bool
+	// replayHook is provided by the DB consumer. If provided,
+	// it is called after reading every record during DB replay.
+	replayHookFunc ReplayHookFunc
 	// cutHook is provided by the DB consumer. If provided,
 	// it is called by DB after every Log is cut.
 	cutHook CutHookFunc
@@ -134,6 +96,8 @@ type db struct {
 }
 
 func (d *db) Append(t Type, value []byte) error {
+	d.panicIfNotReplayed()
+
 	var err error
 	r := &record{
 		Type:  t,
@@ -170,10 +134,13 @@ func (d *db) appendWouldExceedLimits(log *logFile, r *record) bool {
 }
 
 func (d *db) Sync() error {
+	d.panicIfNotReplayed()
 	return d.activeLog().Sync()
 }
 
 func (d *db) Get(t Type, i int) ([]byte, error) {
+	d.panicIfNotReplayed()
+
 	ptr, err := d.inventory.Get(t, i)
 	if err != nil {
 		return nil, fmt.Errorf("could not get pointer to record: %w", err)
@@ -183,10 +150,12 @@ func (d *db) Get(t Type, i int) ([]byte, error) {
 }
 
 func (d *db) Count(t Type) int {
+	d.panicIfNotReplayed()
 	return d.inventory.Count(t)
 }
 
 func (d *db) First(t Type) ([]byte, error) {
+	d.panicIfNotReplayed()
 	ptr, err := d.inventory.Get(t, 0)
 	if err != nil {
 		return nil, err
@@ -196,6 +165,7 @@ func (d *db) First(t Type) ([]byte, error) {
 }
 
 func (d *db) Last(t Type) ([]byte, error) {
+	d.panicIfNotReplayed()
 	ptr, err := d.inventory.Get(t, d.inventory.Count(t)-1)
 	if err != nil {
 		return nil, err
@@ -205,6 +175,7 @@ func (d *db) Last(t Type) ([]byte, error) {
 }
 
 func (d *db) Range(t Type, lo, hi int) iter.Seq2[[]byte, error] {
+	d.panicIfNotReplayed()
 	return func(yield func([]byte, error) bool) {
 		pointers, err := d.inventory.Range(t, lo, hi)
 		if err != nil {
@@ -227,24 +198,91 @@ func (d *db) valueAt(p pointer) ([]byte, error) {
 	return value, err
 }
 
+func (d *db) Replay() error {
+	logFiles, err := discoverLogFiles(d.dir)
+	if err != nil {
+		return err
+	}
+
+	for i, name := range logFiles {
+		name := filepath.Join(d.dir, name)
+		log, err := openLogFile(name)
+		if err != nil {
+			return err
+		}
+
+		// Read the entire log to rebuild our in-memory inventory of records.
+		for record := range log.All() {
+			offset, size := log.Pointer()
+
+			d.inventory.Add(record.Type, pointer{
+				Log:    log.ID,
+				Offset: offset,
+				Size:   size,
+			})
+
+			if d.replayHookFunc != nil {
+				if err := d.replayHookFunc(record.Type, record.Value); err != nil {
+					return fmt.Errorf("%w: %w", ErrReplayHookFailed, err)
+				}
+			}
+		}
+
+		// Lock all but the last log file.
+		if i != len(logFiles)-1 {
+			if err := log.Lock(); err != nil {
+				return err
+			}
+		}
+
+		d.logs = append(d.logs, log)
+		d.sequence++
+	}
+
+	if len(d.logs) == 0 {
+		_, err := d.newLog()
+		if err != nil {
+			return err
+		}
+	}
+
+	d.offset = uint64(d.logs[0].ID)
+	d.replayed = true
+
+	return nil
+}
+
+func (d *db) ReplayHook(f ReplayHookFunc) {
+	d.replayHookFunc = f
+}
+
+func (d *db) panicIfNotReplayed() {
+	if !d.replayed {
+		panic(ErrMustReplay)
+	}
+}
+
 func (d *db) Cut() error {
+	d.panicIfNotReplayed()
 	_, err := d.cut()
 	return err
 }
 
-func (d *db) CutHook(h CutHookFunc) {
-	d.cutHook = h
+func (d *db) CutHook(f CutHookFunc) {
+	d.cutHook = f
 }
 
 func (d *db) Compact() error {
+	d.panicIfNotReplayed()
 	return d.compact()
 }
 
-func (d *db) CompactHook(h CompactHookFunc) {
-	d.compactHook = h
+func (d *db) CompactHook(f CompactHookFunc) {
+	d.compactHook = f
 }
 
 func (d *db) Close() error {
+	d.panicIfNotReplayed()
 	for _, log := range d.logs[:len(d.logs)-1] {
 		if err := log.Close(); err != nil {
 			return err

--- a/cluster/raft/qwal/db_test.go
+++ b/cluster/raft/qwal/db_test.go
@@ -2,6 +2,7 @@ package qwal
 
 import (
 	"errors"
+	"fmt"
 	"math/rand/v2"
 	"testing"
 
@@ -10,7 +11,7 @@ import (
 
 func TestDBAppend(t *testing.T) {
 	t.Run("Appended values are retrievable", func(t *testing.T) {
-		db := testDB(t, t.TempDir(), nil)
+		db := testReplayedDB(t, t.TempDir(), nil)
 
 		wantType := randomType()
 		wantValues := RandomBytesN(5, 16, 32)
@@ -38,7 +39,7 @@ func TestDBAppend(t *testing.T) {
 	})
 
 	t.Run("Append triggers Cut when MaxLogSize exceeded", func(t *testing.T) {
-		db := testDB(t, t.TempDir(), &Options{
+		db := testReplayedDB(t, t.TempDir(), &Options{
 			MaxLogSize: 64,
 		})
 
@@ -57,7 +58,7 @@ func TestDBAppend(t *testing.T) {
 	})
 
 	t.Run("Append triggers Cut when MaxLogRecordCount exceeded", func(t *testing.T) {
-		db := testDB(t, t.TempDir(), &Options{
+		db := testReplayedDB(t, t.TempDir(), &Options{
 			MaxLogValueCount: 1,
 		})
 
@@ -76,7 +77,7 @@ func TestDBAppend(t *testing.T) {
 	})
 
 	t.Run("Append triggers Compact when MaxLogCount exceeded", func(t *testing.T) {
-		db := testDB(t, t.TempDir(), &Options{
+		db := testReplayedDB(t, t.TempDir(), &Options{
 			MaxLogValueCount: 1,
 			MaxLogCount:      1,
 		})
@@ -97,7 +98,7 @@ func TestDBAppend(t *testing.T) {
 }
 
 func TestDBGet(t *testing.T) {
-	db := testDB(t, t.TempDir(), nil)
+	db := testReplayedDB(t, t.TempDir(), nil)
 
 	wantType, wantValue := randomType(), RandomBytes(32)
 
@@ -123,7 +124,7 @@ func TestDBGet(t *testing.T) {
 
 func TestDBCut(t *testing.T) {
 	t.Run("Cut provisions a new Log every time it is called", func(t *testing.T) {
-		db := testDB(t, t.TempDir(), nil).(*db)
+		db := testReplayedDB(t, t.TempDir(), nil).(*db)
 
 		target := 5
 
@@ -138,7 +139,7 @@ func TestDBCut(t *testing.T) {
 	})
 
 	t.Run("Cut calls CutHook", func(t *testing.T) {
-		db := testDB(t, t.TempDir(), nil)
+		db := testReplayedDB(t, t.TempDir(), nil)
 
 		want := true
 		got := false
@@ -153,7 +154,7 @@ func TestDBCut(t *testing.T) {
 	})
 
 	t.Run("LogID is passed to CutHook and incremented correctly", func(t *testing.T) {
-		db := testDB(t, t.TempDir(), nil)
+		db := testReplayedDB(t, t.TempDir(), nil)
 
 		var got LogID
 		db.CutHook(func(id LogID) error {
@@ -169,7 +170,7 @@ func TestDBCut(t *testing.T) {
 	})
 
 	t.Run("Error from CutHook is bubbled up to Cut", func(t *testing.T) {
-		db := testDB(t, t.TempDir(), nil)
+		db := testReplayedDB(t, t.TempDir(), nil)
 
 		want := errors.New("error when calling CutHook")
 		db.CutHook(func(id LogID) error {
@@ -184,7 +185,7 @@ func TestDBCut(t *testing.T) {
 
 func TestDBCompact(t *testing.T) {
 	t.Run("Compact removes a Log", func(t *testing.T) {
-		db := testDB(t, t.TempDir(), nil).(*db)
+		db := testReplayedDB(t, t.TempDir(), nil).(*db)
 
 		// Verify that we start with one Log.
 		got := len(db.logs)
@@ -206,14 +207,14 @@ func TestDBCompact(t *testing.T) {
 	})
 
 	t.Run("Compact when DB contains just one Log returns ErrInvalidCompaction", func(t *testing.T) {
-		db := testDB(t, t.TempDir(), nil)
+		db := testReplayedDB(t, t.TempDir(), nil)
 
 		err := db.Compact()
 		AssertErrorIs(t, err, ErrInvalidCompaction)
 	})
 
 	t.Run("Compact calls CompactHook", func(t *testing.T) {
-		db := testDB(t, t.TempDir(), nil)
+		db := testReplayedDB(t, t.TempDir(), nil)
 
 		called := false
 		db.CompactHook(func(c Counters) error {
@@ -231,7 +232,7 @@ func TestDBCompact(t *testing.T) {
 	})
 
 	t.Run("Error in CompactHook is bubbled up to Compact", func(t *testing.T) {
-		db := testDB(t, t.TempDir(), nil)
+		db := testReplayedDB(t, t.TempDir(), nil)
 
 		want := errors.New("error when calling CompactHook")
 		db.CompactHook(func(c Counters) error {
@@ -250,7 +251,7 @@ func TestDBCompact(t *testing.T) {
 func TestDBOpenExisting(t *testing.T) {
 	t.Run("re-open db and write data", func(t *testing.T) {
 		dir := t.TempDir()
-		db := testDB(t, dir, nil)
+		db := testReplayedDB(t, dir, nil)
 
 		// Generate some random values to write.
 		// Half will be written now, and half after recovery.
@@ -267,7 +268,7 @@ func TestDBOpenExisting(t *testing.T) {
 		AssertNoError(t, err).Require()
 
 		// Re-open DB and rebuild state from directory.
-		db = testDB(t, dir, nil)
+		db = testReplayedDB(t, dir, nil)
 
 		// Write the remaining values
 		for i := len(wantValues) / 2; i < len(wantValues); i++ {
@@ -285,7 +286,7 @@ func TestDBOpenExisting(t *testing.T) {
 
 	t.Run("recover after cuts and compactions", func(t *testing.T) {
 		dir := t.TempDir()
-		db := testDB(t, dir, &Options{
+		db := testReplayedDB(t, dir, &Options{
 			MaxLogCount: 8,
 		})
 
@@ -309,7 +310,7 @@ func TestDBOpenExisting(t *testing.T) {
 		AssertNoError(t, err).Require()
 
 		// Open a new DB in the same directory.
-		db = testDB(t, dir, nil)
+		db = testReplayedDB(t, dir, nil)
 
 		// Check all remaining values
 		for i := range remainingValueCount {
@@ -320,10 +321,150 @@ func TestDBOpenExisting(t *testing.T) {
 	})
 }
 
+func TestDBReplay(t *testing.T) {
+	dir := t.TempDir()
+	db := testDB(t, dir, nil)
+	err := db.Replay()
+	AssertNoError(t, err).Require()
+
+	records := randomRecordsN(10, 32, 64)
+	for _, record := range records {
+		err := db.Append(record.Type, record.Value)
+		AssertNoError(t, err).Require()
+	}
+
+	err = db.Close()
+	AssertNoError(t, err).Require()
+
+	t.Run("iterates over records in the DB", func(t *testing.T) {
+		db := testDB(t, dir, nil)
+
+		i := 0
+		db.ReplayHook(func(rt Type, value []byte) error {
+			AssertEqual(t, rt, records[i].Type)
+			AssertSlicesEqual(t, value, records[i].Value)
+			i++
+			return nil
+		})
+
+		err = db.Replay()
+		AssertNoError(t, err)
+		AssertEqual(t, i, len(records))
+	})
+
+	t.Run("returns error in ReplayHook", func(t *testing.T) {
+		db := testDB(t, dir, nil)
+		want := errors.New("oops")
+
+		db.ReplayHook(func(t Type, value []byte) error {
+			return want
+		})
+
+		err := db.Replay()
+		AssertErrorIs(t, err, ErrReplayHookFailed, want)
+	})
+
+	t.Run("can replay without a hook registered", func(t *testing.T) {
+		db := testDB(t, dir, nil)
+		err := db.Replay()
+		AssertNoError(t, err).Require()
+	})
+
+	t.Run("reading or writing panics before replaying", func(t *testing.T) {
+		db := testDB(t, dir, nil)
+
+		tc := []struct {
+			name   string
+			method func(db DB) error
+		}{
+			{
+				name: "Append",
+				method: func(db DB) error {
+					return db.Append(1, nil)
+				},
+			},
+			{
+				name: "Get",
+				method: func(db DB) error {
+					_, err := db.Get(0, 0)
+					return err
+				},
+			},
+			{
+				name: "Count",
+				method: func(db DB) error {
+					db.Count(0)
+					return nil
+				},
+			},
+			{
+				name: "First",
+				method: func(db DB) error {
+					_, err := db.First(0)
+					return err
+				},
+			},
+			{
+				name: "Last",
+				method: func(db DB) error {
+					_, err := db.Last(0)
+					return err
+				},
+			},
+			{
+				name: "Range",
+				method: func(db DB) error {
+					db.Range(0, 0, 0)
+					return err
+				},
+			},
+			{
+				name: "Cut",
+				method: func(db DB) error {
+					return db.Cut()
+				},
+			},
+			{
+				name: "Compact",
+				method: func(db DB) error {
+					return db.Compact()
+				},
+			},
+			{
+				name: "Sync",
+				method: func(db DB) error {
+					return db.Sync()
+				},
+			},
+			{
+				name: "Close",
+				method: func(db DB) error {
+					return db.Close()
+				},
+			},
+		}
+
+		for _, tt := range tc {
+			name := fmt.Sprintf("method: %s", tt.name)
+			t.Run(name, func(t *testing.T) {
+				defer AssertPanics(t, ErrMustReplay)
+				err := tt.method(db)
+				AssertNoError(t, err)
+			})
+		}
+	})
+}
+
 func testDB(t *testing.T, dir string, opts *Options) DB {
 	db, err := Open(dir, opts)
 	AssertNoError(t, err).Require()
+	return db
+}
 
+func testReplayedDB(t *testing.T, dir string, opts *Options) DB {
+	db := testDB(t, dir, opts)
+	err := db.Replay()
+	AssertNoError(t, err).Require()
 	return db
 }
 

--- a/cluster/raft/qwal/errors.go
+++ b/cluster/raft/qwal/errors.go
@@ -14,6 +14,8 @@ var (
 
 	// QWAL errors
 	ErrInvalidCompaction = errors.New("invalid compaction")
+	ErrMustReplay        = errors.New("db must be replayed before use")
+	ErrReplayHookFailed  = errors.New("replay hook failed")
 	ErrCutHookFailed     = errors.New("cut hook failed")
 	ErrCompactHookFailed = errors.New("compact hook failed")
 )

--- a/cluster/raft/qwal/example_dump_test.go
+++ b/cluster/raft/qwal/example_dump_test.go
@@ -13,7 +13,7 @@ const (
 func ExampleDumpLog() {
 	// Open a Log created by QWAL.
 	f, _ := os.Open("00000000000000000012.log")
-	defer f.Close() // nolint: errcheck
+	defer f.Close()
 
 	for t, val := range DumpLog(f) {
 		switch t {

--- a/cluster/raft/qwal/example_test.go
+++ b/cluster/raft/qwal/example_test.go
@@ -7,38 +7,52 @@ import (
 
 const (
 	// Define our own Types as constants.
-	TypeSetup Type = iota
-	TypePunchline
+	TypeLetter Type = iota
+	TypeDigit
+)
+
+var (
+	letters = []string{
+		"A", "B", "C", "D", "E", "F", "G", "H", "I", "J",
+		"K", "L", "M", "N", "O", "P", "Q", "R", "S", "T",
+		"U", "V", "W", "X", "Y", "Z",
+	}
+	digits = []string{
+		"0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+	}
 )
 
 func Example() {
 	// Open the DB.
 	dir, _ := os.MkdirTemp(os.TempDir(), "db")
-	defer os.RemoveAll(dir) // nolint: errcheck
+	defer os.RemoveAll(dir)
 
 	db, err := Open(dir, nil)
 	if err != nil {
 		panic(err)
 	}
-	defer db.Close() // nolint: errcheck
+	// Always replay the DB before using it.
+	db.Replay()
+	defer db.Close()
 
-	// Write some values.
-	db.Append(TypeSetup, []byte("Why did the chicken cross the road?")) // nolint: errcheck
-	db.Append(TypePunchline, []byte("To get to the other side."))       // nolint: errcheck
-	db.Append(TypePunchline, []byte("This is a lame joke."))            // nolint: errcheck
+	// Write some values
+	for _, letter := range letters {
+		db.Append(TypeLetter, []byte(letter))
+	}
+	for _, digit := range digits {
+		db.Append(TypeDigit, []byte(digit))
+	}
 
-	// Use some of the available methods for reading.
-	val, _ := db.Get(TypeSetup, 0)
-	fmt.Println(string(val))
+	firstLetter, _ := db.First(TypeLetter)
+	lastLetter, _ := db.Last(TypeLetter)
+	fmt.Printf("From %s to %s...\n", firstLetter, lastLetter)
 
-	val, _ = db.Last(TypePunchline)
-	fmt.Println(string(val))
-
-	val, _ = db.First(TypePunchline)
-	fmt.Println(string(val))
+	fmt.Print("As easy as...")
+	for d, _ := range db.Range(TypeDigit, 1, 4) {
+		fmt.Printf(" %s", d)
+	}
 
 	// Output:
-	// Why did the chicken cross the road?
-	// This is a lame joke.
-	// To get to the other side.
+	// From A to Z...
+	// As easy as... 1 2 3
 }

--- a/cluster/raft/qwal/interface.go
+++ b/cluster/raft/qwal/interface.go
@@ -23,21 +23,25 @@ type (
 		// Range returns an iterator that ranges over all values of Type t
 		// in the range [lo, hi[.
 		Range(t Type, lo, hi int) iter.Seq2[[]byte, error]
+		// TODO: Comment
+		Replay() error
+		// TODO: Comment
+		ReplayHook(f ReplayHookFunc)
 		// Cut manually cuts a new Log in the DB. Cutting a Log is normally
 		// triggered automatically when MaxLogSize or MaxLogRecordCount is
 		// exceeded. Instead, Cut may be used to trigger them manually when more
 		// control is required, like for tests. As such, Cut does not consider
 		// MaxLogSize and MaxLogRecordCount.
 		Cut() error
+		// CutHook registers CutHookFunc f, which is run whenever a Log is cut.
+		// To clear the CutHook, call CutHook with a nil argument.
+		CutHook(f CutHookFunc)
 		// Compact manually triggers a compaction. Compactions are normally
 		// triggered automatically when MaxLogCount is exceeded. Instead,
 		// Compact may be used to trigger them manually when more control
 		// is required, like for tests. As such, Compact does not consider MaxLogCount.
 		// Attempting to Compact when the DB only contains one Log returns ErrInvalidCompaction.
 		Compact() error
-		// CutHook registers CutHookFunc f, which is run whenever a Log is cut.
-		// To clear the CutHook, call CutHook with a nil argument.
-		CutHook(f CutHookFunc)
 		// CompactHook registers CompactHook f, which is run whenever DB compacts a Log.
 		// To clear the CompactHook, call CompactHook with a nil argument.
 		CompactHook(f CompactHookFunc)
@@ -55,6 +59,10 @@ type (
 
 	// LogID represents the sequential ID of a Log in the DB.
 	LogID uint64
+
+	// TODO: Comment
+	// Returning an error from the ReplayHookFunc stops the replay.
+	ReplayHookFunc func(t Type, value []byte) error
 
 	// CutHookFunc is executed whenever a Log is cut. A Log is cut when it reaches
 	// its maximum size and is moved into read-only mode. A new Log is then

--- a/cluster/raft/storage.go
+++ b/cluster/raft/storage.go
@@ -23,6 +23,10 @@ func NewDiskStorage(db qwal.DB, snap cluster.Snapshotter) (*DiskStorage, error) 
 		snap: snap,
 	}
 
+	if err := db.Replay(); err != nil {
+		return nil, err
+	}
+
 	if s.db.Count(TypeEntry) > 0 {
 		value, err := s.db.First(TypeEntry)
 		if err != nil {

--- a/cluster/raft/storage_test.go
+++ b/cluster/raft/storage_test.go
@@ -382,7 +382,6 @@ func testDB(t *testing.T, opts *qwal.Options) qwal.DB {
 	dir := t.TempDir()
 	db, err := qwal.Open(dir, opts)
 	AssertNoError(t, err).Require()
-
 	return db
 }
 

--- a/testing/assert.go
+++ b/testing/assert.go
@@ -42,12 +42,21 @@ func AssertErrorIs(t testing.TB, got error, want ...error) *Result {
 }
 
 func AssertPanics(t testing.TB, want error) {
+	t.Helper()
+
 	got := recover()
 	if got == nil {
 		t.Error("expected a panic")
+		return
 	}
 
-	AssertErrorIs(t, got.(error), want)
+	err, ok := got.(error)
+	if !ok {
+		t.Error("expected panic to have an error")
+		return
+	}
+
+	AssertErrorIs(t, err, want)
 }
 
 func AssertNoError(t testing.TB, got error) *Result {


### PR DESCRIPTION
Basically just moving code that was in `db.Open()` into new `db.Replay()` method that the DB consumer is supposed to use.
Also allows registering a `db.ReplayHookFunc`  that is called for every record read during replay.

Preparation for #148.