### PR TITLE
Enable import formatting through golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,11 @@
 version: "2"
+formatters:
+  enable:
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/robinkb/cascade
 linters:
   exclusions:
     paths:

--- a/cluster/raft/node.go
+++ b/cluster/raft/node.go
@@ -9,10 +9,11 @@ import (
 	"slices"
 	"time"
 
-	"github.com/robinkb/cascade/cluster"
-	"github.com/robinkb/cascade/pkg/process"
 	"go.etcd.io/raft/v3"
 	"go.etcd.io/raft/v3/raftpb"
+
+	"github.com/robinkb/cascade/cluster"
+	"github.com/robinkb/cascade/pkg/process"
 )
 
 type (

--- a/cluster/raft/node_confchange.go
+++ b/cluster/raft/node_confchange.go
@@ -7,8 +7,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/robinkb/cascade/cluster"
 	"go.etcd.io/raft/v3/raftpb"
+
+	"github.com/robinkb/cascade/cluster"
 )
 
 // AsPeer returns a [cluster.Peer] representing this node.

--- a/cluster/raft/node_test.go
+++ b/cluster/raft/node_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 	"time"
 
+	"go.etcd.io/raft/v3"
+
 	"github.com/robinkb/cascade/cluster"
 	"github.com/robinkb/cascade/cluster/fake"
 	"github.com/robinkb/cascade/cluster/raft/qwal"
 	"github.com/robinkb/cascade/pkg/server"
 	. "github.com/robinkb/cascade/testing"
-	"go.etcd.io/raft/v3"
 )
 
 func TestNodeLifecycle(t *testing.T) {

--- a/cluster/raft/qwal/log_test.go
+++ b/cluster/raft/qwal/log_test.go
@@ -7,8 +7,9 @@ import (
 	"syscall"
 	"testing"
 
-	. "github.com/robinkb/cascade/testing"
 	"golang.org/x/exp/mmap"
+
+	. "github.com/robinkb/cascade/testing"
 )
 
 func testReaderWriter(t testing.TB) (io.ReaderAt, io.WriteSeeker) {

--- a/cluster/raft/storage.go
+++ b/cluster/raft/storage.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/robinkb/cascade/cluster"
-	"github.com/robinkb/cascade/cluster/raft/qwal"
 	"go.etcd.io/raft/v3"
 	"go.etcd.io/raft/v3/raftpb"
+
+	"github.com/robinkb/cascade/cluster"
+	"github.com/robinkb/cascade/cluster/raft/qwal"
 )
 
 const (

--- a/cmd/dump/main.go
+++ b/cmd/dump/main.go
@@ -6,9 +6,10 @@ import (
 	"log"
 	"os"
 
+	"go.etcd.io/raft/v3/raftpb"
+
 	"github.com/robinkb/cascade/cluster/raft"
 	"github.com/robinkb/cascade/cluster/raft/qwal"
-	"go.etcd.io/raft/v3/raftpb"
 )
 
 var (

--- a/registry/api/v2/blob_uploads_test.go
+++ b/registry/api/v2/blob_uploads_test.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/opencontainers/go-digest"
+	tmock "github.com/stretchr/testify/mock"
+
 	"github.com/robinkb/cascade/registry/repository"
 	. "github.com/robinkb/cascade/testing"
 	"github.com/robinkb/cascade/testing/repository/mock"
-	tmock "github.com/stretchr/testify/mock"
 )
 
 func TestBlobUploadsMonolithic(t *testing.T) {

--- a/registry/api/v2/ext_catalog_test.go
+++ b/registry/api/v2/ext_catalog_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	v1 "github.com/opencontainers/distribution-spec/specs-go/v1"
+
 	. "github.com/robinkb/cascade/testing"
 	testclient "github.com/robinkb/cascade/testing/client"
 	"github.com/robinkb/cascade/testing/registry/mock"

--- a/registry/api/v2/manifests.go
+++ b/registry/api/v2/manifests.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/robinkb/cascade/registry/repository"
 )
 

--- a/registry/api/v2/manifests_test.go
+++ b/registry/api/v2/manifests_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/robinkb/cascade/registry/repository"
 	"github.com/robinkb/cascade/registry/store"
 	. "github.com/robinkb/cascade/testing"

--- a/registry/api/v2/referrers.go
+++ b/registry/api/v2/referrers.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/robinkb/cascade/registry/repository"
 )
 

--- a/registry/api/v2/referrers_test.go
+++ b/registry/api/v2/referrers_test.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	tmock "github.com/stretchr/testify/mock"
+
 	"github.com/robinkb/cascade/registry/repository"
 	. "github.com/robinkb/cascade/testing"
 	testclient "github.com/robinkb/cascade/testing/client"
 	"github.com/robinkb/cascade/testing/repository/mock"
-	tmock "github.com/stretchr/testify/mock"
 )
 
 func TestListReferrers(t *testing.T) {

--- a/registry/api/v2/tags_test.go
+++ b/registry/api/v2/tags_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	v1 "github.com/opencontainers/distribution-spec/specs-go/v1"
+
 	. "github.com/robinkb/cascade/testing"
 	testclient "github.com/robinkb/cascade/testing/client"
 	"github.com/robinkb/cascade/testing/repository/mock"

--- a/registry/api/v2/upload_sessions_test.go
+++ b/registry/api/v2/upload_sessions_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gofrs/uuid/v5"
+
 	"github.com/robinkb/cascade/registry/repository"
 	"github.com/robinkb/cascade/registry/store"
 	. "github.com/robinkb/cascade/testing"

--- a/registry/repository/blobs.go
+++ b/registry/repository/blobs.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/robinkb/cascade/registry/store"
 )
 

--- a/registry/repository/manifest_test.go
+++ b/registry/repository/manifest_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/robinkb/cascade/registry/store"
 	. "github.com/robinkb/cascade/testing"
 	. "github.com/robinkb/cascade/testing/repository"

--- a/registry/repository/manifests.go
+++ b/registry/repository/manifests.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/robinkb/cascade/registry/store"
 )
 

--- a/registry/repository/service.go
+++ b/registry/repository/service.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/robinkb/cascade/registry/store"
 )
 

--- a/registry/repository/tags.go
+++ b/registry/repository/tags.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/opencontainers/go-digest"
+
 	"github.com/robinkb/cascade/registry/store"
 )
 

--- a/registry/repository/tags_test.go
+++ b/registry/repository/tags_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/go-digest"
+
 	. "github.com/robinkb/cascade/testing"
 	. "github.com/robinkb/cascade/testing/repository"
 	"github.com/robinkb/cascade/testing/store/mock"

--- a/registry/repository/uploads.go
+++ b/registry/repository/uploads.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gofrs/uuid/v5"
 	godigest "github.com/opencontainers/go-digest"
+
 	"github.com/robinkb/cascade/registry/store"
 )
 

--- a/registry/store/driver/boltdb/metadata.go
+++ b/registry/store/driver/boltdb/metadata.go
@@ -12,9 +12,10 @@ import (
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/opencontainers/go-digest"
-	"github.com/robinkb/cascade/registry/store"
 	bolt "go.etcd.io/bbolt"
 	bolterrors "go.etcd.io/bbolt/errors"
+
+	"github.com/robinkb/cascade/registry/store"
 )
 
 var (

--- a/registry/store/driver/boltdb/metadata_test.go
+++ b/registry/store/driver/boltdb/metadata_test.go
@@ -3,10 +3,11 @@ package boltdb
 import (
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/robinkb/cascade/registry/store"
 	storesuite "github.com/robinkb/cascade/registry/store/suite"
 	. "github.com/robinkb/cascade/testing"
-	"github.com/stretchr/testify/suite"
 )
 
 func TestMetadataSuite(t *testing.T) {

--- a/registry/store/driver/boltdb/metadata_types.go
+++ b/registry/store/driver/boltdb/metadata_types.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/opencontainers/go-digest"
-	"github.com/robinkb/cascade/registry/store"
 	bolt "go.etcd.io/bbolt"
+
+	"github.com/robinkb/cascade/registry/store"
 )
 
 // Types for wrapping BoltDB queries to codify the database structure.

--- a/registry/store/driver/cluster/blobs_test.go
+++ b/registry/store/driver/cluster/blobs_test.go
@@ -3,11 +3,12 @@ package cluster
 import (
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/robinkb/cascade/cluster/fake"
 	"github.com/robinkb/cascade/registry/store"
 	"github.com/robinkb/cascade/registry/store/driver/inmemory"
 	storesuite "github.com/robinkb/cascade/registry/store/suite"
-	"github.com/stretchr/testify/suite"
 )
 
 func TestBlobSuite(t *testing.T) {

--- a/registry/store/driver/cluster/metadata.go
+++ b/registry/store/driver/cluster/metadata.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"github.com/gofrs/uuid/v5"
 	"github.com/opencontainers/go-digest"
+
 	"github.com/robinkb/cascade/cluster"
 	"github.com/robinkb/cascade/registry/store"
 )

--- a/registry/store/driver/cluster/metadata_test.go
+++ b/registry/store/driver/cluster/metadata_test.go
@@ -3,11 +3,12 @@ package cluster
 import (
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/robinkb/cascade/cluster/fake"
 	"github.com/robinkb/cascade/registry/store"
 	"github.com/robinkb/cascade/registry/store/driver/inmemory"
 	storesuite "github.com/robinkb/cascade/registry/store/suite"
-	"github.com/stretchr/testify/suite"
 )
 
 func TestMetadataSuite(t *testing.T) {

--- a/registry/store/driver/fs/blobs.go
+++ b/registry/store/driver/fs/blobs.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/opencontainers/go-digest"
+
 	"github.com/robinkb/cascade/registry/store"
 )
 

--- a/registry/store/driver/fs/blobs_test.go
+++ b/registry/store/driver/fs/blobs_test.go
@@ -4,10 +4,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/robinkb/cascade/registry/store"
 	storesuite "github.com/robinkb/cascade/registry/store/suite"
 	. "github.com/robinkb/cascade/testing"
-	"github.com/stretchr/testify/suite"
 )
 
 func TestBlobSuite(t *testing.T) {

--- a/registry/store/driver/inmemory/blobs.go
+++ b/registry/store/driver/inmemory/blobs.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/opencontainers/go-digest"
+
 	"github.com/robinkb/cascade/registry/store"
 )
 

--- a/registry/store/driver/inmemory/blobs_test.go
+++ b/registry/store/driver/inmemory/blobs_test.go
@@ -3,9 +3,10 @@ package inmemory
 import (
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/robinkb/cascade/registry/store"
 	storesuite "github.com/robinkb/cascade/registry/store/suite"
-	"github.com/stretchr/testify/suite"
 )
 
 func TestBlobSuite(t *testing.T) {

--- a/registry/store/driver/inmemory/metadata.go
+++ b/registry/store/driver/inmemory/metadata.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/opencontainers/go-digest"
+
 	"github.com/robinkb/cascade/registry/store"
 )
 

--- a/registry/store/driver/inmemory/metadata_test.go
+++ b/registry/store/driver/inmemory/metadata_test.go
@@ -3,9 +3,10 @@ package inmemory
 import (
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/robinkb/cascade/registry/store"
 	storesuite "github.com/robinkb/cascade/registry/store/suite"
-	"github.com/stretchr/testify/suite"
 )
 
 func TestMetadataSuite(t *testing.T) {

--- a/registry/store/driver/inmemory/reconciler_test.go
+++ b/registry/store/driver/inmemory/reconciler_test.go
@@ -3,9 +3,10 @@ package inmemory
 import (
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/robinkb/cascade/registry/store"
 	storesuite "github.com/robinkb/cascade/registry/store/suite"
-	"github.com/stretchr/testify/suite"
 )
 
 func TestReconcilerSuite(t *testing.T) {

--- a/registry/store/metadata.go
+++ b/registry/store/metadata.go
@@ -8,10 +8,11 @@ import (
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/opencontainers/go-digest"
-	"github.com/robinkb/cascade/pkg/pbutil"
-	"github.com/robinkb/cascade/registry/store/storepb"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/robinkb/cascade/pkg/pbutil"
+	"github.com/robinkb/cascade/registry/store/storepb"
 )
 
 var (

--- a/registry/store/suite/blobs.go
+++ b/registry/store/suite/blobs.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/robinkb/cascade/registry/store"
 	. "github.com/robinkb/cascade/testing" // nolint: staticcheck
-	"github.com/stretchr/testify/suite"
 )
 
 type BlobStoreConstructor func(t *testing.T) store.Blobs

--- a/registry/store/suite/metadata.go
+++ b/registry/store/suite/metadata.go
@@ -9,10 +9,11 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/robinkb/cascade/registry/store"
 	. "github.com/robinkb/cascade/testing"            // nolint: staticcheck
 	. "github.com/robinkb/cascade/testing/repository" // nolint: staticcheck
-	"github.com/stretchr/testify/suite"
 )
 
 type MetadataStoreConstructor func(t *testing.T) store.Metadata

--- a/registry/store/suite/reconciler.go
+++ b/registry/store/suite/reconciler.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/robinkb/cascade/registry/store"
 	. "github.com/robinkb/cascade/testing" // nolint: staticcheck
-	"github.com/stretchr/testify/suite"
 )
 
 type ReconcilerSuite struct {

--- a/testing/client/client.go
+++ b/testing/client/client.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
 	. "github.com/robinkb/cascade/testing" //nolint: staticcheck
 )
 

--- a/testing/conformance/content_discovery_test.go
+++ b/testing/conformance/content_discovery_test.go
@@ -7,6 +7,7 @@ import (
 
 	distributionv1 "github.com/opencontainers/distribution-spec/specs-go/v1"
 	imagev1 "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/robinkb/cascade/registry"
 	v2 "github.com/robinkb/cascade/registry/api/v2"
 	"github.com/robinkb/cascade/registry/store/driver/inmemory"

--- a/testing/repository/builder.go
+++ b/testing/repository/builder.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/robinkb/cascade/registry/store"
 	. "github.com/robinkb/cascade/testing" // nolint: staticcheck
 )


### PR DESCRIPTION
Just makes import order consistent.