### PR TITLE
Run `go fix` and add it to the `lint` task

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -113,6 +113,7 @@ tasks:
   lint:
     desc: run static quality checks
     cmds:
+      - cmd: go fix -diff ./...
       - cmd: go mod tidy -diff
       - cmd: go tool buf format --write
       - cmd: go tool golangci-lint run ./... --fix

--- a/cluster/operator/controller_node.go
+++ b/cluster/operator/controller_node.go
@@ -11,7 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -68,7 +67,7 @@ func (r *nodeController) Reconcile(ctx context.Context, req ctrl.Request) (resul
 			}
 			es.Ports = []discoveryv1.EndpointPort{
 				discoveryv1.EndpointPort{
-					Port: ptr.To(int32(addr.Port())),
+					Port: new(int32(addr.Port())),
 				},
 			}
 			return nil
@@ -101,7 +100,7 @@ func (r *nodeController) SetupWithManager(mgr manager.Manager) error {
 		Named("cascade-node-controller").
 		For(&discoveryv1.EndpointSlice{}).
 		WithOptions(controller.TypedOptions[reconcile.Request]{
-			NeedLeaderElection: ptr.To(false),
+			NeedLeaderElection: new(false),
 		}).
 		WatchesRawSource(&RaftEventSource{r.self, r.node}).
 		Complete(r)

--- a/cluster/operator/controller_node_test.go
+++ b/cluster/operator/controller_node_test.go
@@ -42,7 +42,7 @@ func testControllerNode(t *testing.T, c client.Client) {
 			},
 			Ports: []discoveryv1.EndpointPort{
 				discoveryv1.EndpointPort{
-					Port: ptr.To(int32(port)),
+					Port: new(int32(port)),
 				},
 			},
 		}

--- a/cluster/raft/storage_test.go
+++ b/cluster/raft/storage_test.go
@@ -211,9 +211,9 @@ func TestStorageSaveHardState(t *testing.T) {
 	store := newTestStore(t, t.TempDir())
 
 	want := &raftpb.HardState{
-		Term:   ptr(rand.Uint64()),
-		Vote:   ptr(rand.Uint64()),
-		Commit: ptr(rand.Uint64()),
+		Term:   new(rand.Uint64()),
+		Vote:   new(rand.Uint64()),
+		Commit: new(rand.Uint64()),
 	}
 
 	err := store.SaveHardState(want)
@@ -237,7 +237,7 @@ func TestStorageSnapshot(t *testing.T) {
 		wantApliedIndex := entries[0].GetIndex()
 		wantTerm := entries[0].GetTerm()
 		wantConfState := &raftpb.ConfState{
-			AutoLeave: ptr(true),
+			AutoLeave: new(true),
 			Voters:    []uint64{rand.Uint64(), rand.Uint64(), rand.Uint64()},
 		}
 
@@ -278,8 +278,8 @@ func TestStorageSnapshot(t *testing.T) {
 		want := &raftpb.Snapshot{
 			Data: RandomBytes(64),
 			Metadata: &raftpb.SnapshotMetadata{
-				Index:     ptr(uint64(10)),
-				Term:      ptr(uint64(5)),
+				Index:     new(uint64(10)),
+				Term:      new(uint64(5)),
 				ConfState: &raftpb.ConfState{Voters: RandomIntN[uint64](3)},
 			},
 		}
@@ -464,8 +464,4 @@ func newTestStore(t *testing.T, dir string) *DiskStorage {
 	store, err := NewDiskStorage(dir, testDB(t, dir, nil), new(fake.Snapshotter))
 	AssertNoError(t, err).Require()
 	return store
-}
-
-func ptr[T any](v T) *T {
-	return &v
 }

--- a/cmd/cascade-registry/main.go
+++ b/cmd/cascade-registry/main.go
@@ -168,7 +168,7 @@ func yamlResolver(r io.Reader) (kong.Resolver, error) {
 			return raw, nil
 		}
 		raw = values
-		for _, part := range strings.Split(name, ".") {
+		for part := range strings.SplitSeq(name, ".") {
 			if values, ok := raw.(map[string]any); ok {
 				raw, ok = values[part]
 				if !ok {

--- a/go.work.sum
+++ b/go.work.sum
@@ -46,6 +46,7 @@ github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7Lk
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=

--- a/registry/api/v2/ext_catalog_test.go
+++ b/registry/api/v2/ext_catalog_test.go
@@ -43,7 +43,7 @@ func TestListRepositories(t *testing.T) {
 		client := testclient.NewForHandler(t, srv)
 
 		resp := client.ListRepositories(&testclient.ListOptions{
-			N:    testclient.Pointer(count),
+			N:    new(count),
 			Last: last,
 		})
 

--- a/registry/api/v2/tags_test.go
+++ b/registry/api/v2/tags_test.go
@@ -43,7 +43,7 @@ func TestListTags(t *testing.T) {
 		client := NewTestClientForRepository(t, name, repo)
 
 		resp := client.ListTags(name, &testclient.ListOptions{
-			N:    testclient.Pointer(count),
+			N:    new(count),
 			Last: last,
 		})
 

--- a/registry/store/metadata.go
+++ b/registry/store/metadata.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/opencontainers/go-digest"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/robinkb/cascade/pkg/pbutil"
@@ -124,8 +123,8 @@ type References struct {
 
 func (r *References) Marshal() []byte {
 	b := storepb.References_builder{
-		Config:  proto.String(r.Config.String()),
-		Subject: proto.String(r.Subject.String()),
+		Config:  new(r.Config.String()),
+		Subject: new(r.Subject.String()),
 	}
 	for _, id := range r.Layers {
 		b.Layers = append(b.Layers, id.String())

--- a/testing/client/client.go
+++ b/testing/client/client.go
@@ -237,10 +237,6 @@ func (c *Client) Do(method string, path string, headers http.Header, body io.Rea
 	return resp.Result()
 }
 
-func Pointer[K any](val K) *K {
-	return &val
-}
-
 type ListOptions struct {
 	N    *int
 	Last string

--- a/testing/conformance/content_discovery_test.go
+++ b/testing/conformance/content_discovery_test.go
@@ -62,7 +62,7 @@ func TestContentDiscovery(t *testing.T) {
 
 			// In addition to fetching the whole list of tags, a subset of the tags can be fetched by providing the n query parameter.
 			resp := client.ListTags(repository, &testclient.ListOptions{
-				N: testclient.Pointer(10),
+				N: new(10),
 			})
 			AssertResponseCode(t, resp, http.StatusOK)
 			var tagsList distributionv1.TagList
@@ -77,7 +77,7 @@ func TestContentDiscovery(t *testing.T) {
 
 			// The response to such a request MAY return fewer than <int> results, but only when the total number of tags attached to the repository is less than <int> or a Link header is provided.
 			resp := client.ListTags(repository, &testclient.ListOptions{
-				N: testclient.Pointer(len(tags) + 10),
+				N: new(len(tags) + 10),
 			})
 			AssertResponseCode(t, resp, http.StatusOK)
 			var tagsList distributionv1.TagList
@@ -90,7 +90,7 @@ func TestContentDiscovery(t *testing.T) {
 			client := testclient.NewForHandler(t, srv)
 
 			resp := client.ListTags(repository, &testclient.ListOptions{
-				N: testclient.Pointer(0),
+				N: new(0),
 			})
 
 			AssertResponseCode(t, resp, http.StatusOK)
@@ -111,7 +111,7 @@ func TestContentDiscovery(t *testing.T) {
 
 			resp := client.ListTags(repository, &testclient.ListOptions{
 				Last: lastTag,
-				N:    testclient.Pointer(n),
+				N:    new(n),
 			})
 
 			AssertResponseCode(t, resp, http.StatusOK)


### PR DESCRIPTION
Mostly replacing helper functions for creating a pointer to primitives. This is no longer necessary since Go 1.26.